### PR TITLE
Add emote-only

### DIFF
--- a/src/chatty/TwitchCommands.java
+++ b/src/chatty/TwitchCommands.java
@@ -74,6 +74,12 @@ public class TwitchCommands {
         else if (command.equals("r9koff")) {
             r9kOff(channel);
         }
+        else if (command.equals("emoteonly")) {
+            emoteonlyOn(channel);
+        }
+        else if (command.equals("emoteonlyoff")) {
+            emoteonlyOff(channel);
+        }
         else if (command.equals("mod")) {
             commandMod(channel, parameter);
         }
@@ -277,6 +283,18 @@ public class TwitchCommands {
     public void r9kOff(String channel) {
         if (onChannel(channel, true)) {
             sendMessage(channel,".r9kbetaoff", "Trying to turn r9k mode off..");
+        }
+    }
+    
+    public void emoteonlyOn(String channel) {
+        if (onChannel(channel, true)) {
+            sendMessage(channel,".emoteonly", "Trying to turn on emote-only mode..");
+        }
+    }
+    
+    public void emoteonlyOff(String channel) {
+        if (onChannel(channel, true)) {
+            sendMessage(channel,".emoteonlyoff", "Trying to turn off emote-only mode..");
         }
     }
     


### PR DESCRIPTION
Add support for newly-added base twitch /emoteonly command that allows you to set your room so only messages that are 100% emotes are allowed and /emoteonlyoff to disable that mode. See http://help.twitch.tv/customer/portal/articles/659095-chat-moderation-commands for reference.

See issue https://github.com/chatty/chatty/issues/34