### PR TITLE
Add automatic log splits and channel subdirectory options

### DIFF
--- a/src/chatty/SettingsManager.java
+++ b/src/chatty/SettingsManager.java
@@ -29,7 +29,7 @@ public class SettingsManager {
     public static final long DISPLAY_NAMES_MODE_CAPITALIZED = 1;
     public static final long DISPLAY_NAMES_MODE_LOCALIZED = 2;
     public static final long DISPLAY_NAMES_MODE_USERNAME = 3;
-    
+
     private final String[] debugSettings = {
         "server",
         "port",
@@ -78,7 +78,7 @@ public class SettingsManager {
         //========
         // General
         //========
-        
+
         settings.addBoolean("dontSaveSettings",false);
         settings.addBoolean("debugCommands", false, false);
         settings.addBoolean("debugLogIrc", false);
@@ -88,7 +88,7 @@ public class SettingsManager {
         // Backup
         settings.addLong("backupDelay", 1);
         settings.addLong("backupCount", 5);
-        
+
         // Version/News
         settings.addLong("versionLastChecked", 0);
         settings.addString("updateAvailable", "");
@@ -114,14 +114,14 @@ public class SettingsManager {
         settings.addList("hotkeys", getDefaultHotkeySettingValue(), Setting.LIST);
         settings.addBoolean("globalHotkeysEnabled", true);
         
-        
+
         //===========
         // Connecting
         //===========
-        
+
         settings.addString("serverDefault", "irc.chat.twitch.tv");
         settings.addString("portDefault", "6697,6667,443,80");
-        
+
         // Seperate settings for commandline/temp so others can be saved
         settings.addString("server", "", false);
         settings.addString("port", "", false);
@@ -129,10 +129,10 @@ public class SettingsManager {
         settings.addList("securedPorts", new LinkedHashSet<>(Arrays.asList((long)6697, (long)443)), Setting.LONG);
         settings.addBoolean("membershipEnabled", true);
         settings.addString("pubsub", "wss://pubsub-edge.twitch.tv");
-        
+
         // Auto-join channels
         settings.addString("channel", "");
-        
+
         // Login Data
         settings.addString("username", "");
         settings.setFile("username", loginFile);
@@ -147,7 +147,7 @@ public class SettingsManager {
         settings.addBoolean("foreignToken", false);
         // Don't save setting, login with password isn't possible anymore
         settings.addBoolean("usePassword", false, false);
-        
+
         // Token
         settings.addBoolean("token_editor", false);
         settings.setFile("token_editor", loginFile);
@@ -165,12 +165,12 @@ public class SettingsManager {
         //=================
         // Appearance / GUI
         //=================
-        
+
         settings.addBoolean("ontop", false);
         settings.addString("laf","default");
         
         settings.addLong("dialogFontSize", -1);
-        
+
         // Chat Appearance
         settings.addString("font","Consolas");
         settings.addLong("fontSize",14);
@@ -203,7 +203,7 @@ public class SettingsManager {
         
         settings.addString("emoji", "twemoji");
         settings.addString("cheersType", "static");
-        
+
         settings.addBoolean("usericonsEnabled",true);
         
         settings.addList("customUsericons", new ArrayList(), Setting.LIST);
@@ -233,11 +233,11 @@ public class SettingsManager {
         // Usercolors
         settings.addBoolean("customUsercolors", false);
         settings.addList("usercolors", new LinkedList(), Setting.STRING);
-        
+
         //====================
         // Other Customization
         //====================
-        
+
         // Addressbook
         settings.addString("abCommandsChannel", "");
         settings.addString("abCommands", "add,set,remove");
@@ -246,18 +246,18 @@ public class SettingsManager {
         settings.addString("abSubMonthsChan", "");
         settings.addList("abSubMonths", new TreeSet(), Setting.LONG);
         settings.addBoolean("abSaveOnChange", false);
-        
+
         // Custom Commands
         settings.addList("commands", new ArrayList(), Setting.STRING);
         // Default entries, will only be set if setting is not loaded from file
         settings.setAdd("commands", "/slap /me slaps $$1- around a bit with a large trout");
         settings.setAdd("commands", "/permit !permit $$1");
-        
+
         // Menu Entries
         settings.addString("timeoutButtons","/Ban[B], /Unban[U], 5s[1], 2m[2], 10m[3], 30m[4]");
         settings.addString("userContextMenu", "");
         settings.addString("channelContextMenu", "");
-        
+
         // History / Favorites
         settings.addMap("channelHistory",new TreeMap(), Setting.LONG);
         settings.setFile("channelHistory", historyFile);
@@ -271,11 +271,11 @@ public class SettingsManager {
         //=======================
         // Channel Admin Features
         //=======================
-        
+
         // Game Presets
         settings.addList("gamesFavorites",new ArrayList(), Setting.STRING);
         settings.setFile("gamesFavorites", historyFile);
-        
+
         // Stream Status Presets
         settings.addList("statusPresets", new ArrayList(), Setting.LIST);
         settings.setFile("statusPresets", statusPresetsFile);
@@ -293,7 +293,7 @@ public class SettingsManager {
         //=======
         // Window
         //=======
-        
+
         // Open URLs
         settings.addBoolean("urlPrompt", true);
         settings.addBoolean("urlCommandEnabled", false);
@@ -315,7 +315,7 @@ public class SettingsManager {
         settings.addMap("windows", new HashMap<>(), Setting.STRING);
         settings.addLong("restoreMode", WindowStateManager.RESTORE_ON_START);
         settings.addBoolean("restoreOnlyIfOnScreen", true);
-        
+
         // Popouts
         settings.addBoolean("popoutSaveAttributes", true);
         settings.addBoolean("popoutCloseLastChannel", true);
@@ -328,19 +328,19 @@ public class SettingsManager {
         settings.addBoolean("titleShowViewerCount", true);
         settings.addBoolean("titleShowChannelState", true);
         settings.addString("titleAddition", "");
-        
+
         // Tabs
         settings.addString("tabOrder", "normal");
         settings.addBoolean("tabsMwheelScrolling", false);
         settings.addBoolean("tabsMwheelScrollingAnywhere", false);
-        
+
         // Chat Window
         settings.addBoolean("chatScrollbarAlways", false);
         settings.addLong("userlistWidth", 120);
         settings.addLong("userlistMinWidth", 0);
         settings.addBoolean("userlistEnabled", true);
         settings.addLong("bufferSize", 500);
-        
+
         settings.addString("liveStreamsSorting", "recent");
         settings.addLong("historyRange", 0);
 
@@ -392,7 +392,7 @@ public class SettingsManager {
         settings.addLong("nActivityTime", 10);
         
         settings.addList("notificationProperties", new ArrayList<>(), Setting.LIST);
-        
+
         settings.addBoolean("tips", true);
         settings.addLong("lastTip", 0);
         
@@ -400,25 +400,25 @@ public class SettingsManager {
         //=====================
         // Basic Chat Behaviour
         //=====================
-        
+
         settings.addString("spamProtection", "18/30");
-        
+
         settings.addBoolean("autoScroll", true);
         settings.addLong("autoScrollTimeout", 30);
         settings.addBoolean("pauseChatOnMouseMove", false);
         settings.addBoolean("pauseChatOnMouseMoveCtrlRequired", false);
         settings.addString("commandOnCtrlClick", "");
-        
+
         // Not really used anymore, kept for compatability
         settings.addBoolean("ignoreJoinsParts",false);
-        
+
         // Message Types
         settings.addBoolean("showJoinsParts", false);
         settings.addBoolean("showModMessages", false);
         settings.addBoolean("twitchnotifyAsInfo", true);
         settings.addBoolean("printStreamStatus", true);
         settings.addBoolean("showModActions", false);
-        
+
         // Timeouts/Bans
         settings.addBoolean("showBanMessages", false);
         settings.addBoolean("banDurationAppended", true);
@@ -438,7 +438,7 @@ public class SettingsManager {
         //==============
         // Chat Features
         //==============
-        
+
         // Highlight
         settings.addList("highlight",new ArrayList(), Setting.STRING);
         settings.addBoolean("highlightEnabled", true);
@@ -447,7 +447,7 @@ public class SettingsManager {
         settings.addBoolean("highlightNextMessages", false);
         settings.addBoolean("highlightIgnored", false);
         settings.addList("noHighlightUsers", new ArrayList(), Setting.STRING);
-        
+
         // Ignore
         settings.addList("ignore", new ArrayList(), Setting.STRING);
         settings.addBoolean("ignoreEnabled", false);
@@ -457,7 +457,7 @@ public class SettingsManager {
         settings.addList("ignoredUsers", new ArrayList(), Setting.STRING);
         settings.addList("ignoredUsersWhisper", new ArrayList(), Setting.STRING);
         settings.addBoolean("ignoredUsersHideInGUI", true);
-        
+
         // Chat Logging
         settings.addString("logMode", "always");
         settings.addBoolean("logMod", true);
@@ -471,6 +471,8 @@ public class SettingsManager {
         settings.addList("logWhitelist",new ArrayList(), Setting.STRING);
         settings.addList("logBlacklist",new ArrayList(), Setting.STRING);
         settings.addString("logPath", "");
+        settings.addString("logSplit", "never");
+        settings.addBoolean("logSubdirectories", false);
         settings.addString("logTimestamp", "[HH:mm:ss]");
         
         // TAB Completion
@@ -482,13 +484,13 @@ public class SettingsManager {
         settings.addBoolean("completionAllNameTypes", true);
         settings.addBoolean("completionPreferUsernames", true);
         settings.addBoolean("completionAllNameTypesRestriction", true);
-        
+
         // Stream Chat
         settings.addLong("streamChatMessageTimeout", -1);
         settings.addList("streamChatChannels", new ArrayList(), Setting.STRING);
         settings.addBoolean("streamChatBottom", true);
         settings.addBoolean("streamChatResizable", true);
-        
+
         // Whispering
         settings.addBoolean("whisperEnabled", false);
         settings.addBoolean("whisperWhitelist", false);
@@ -502,33 +504,33 @@ public class SettingsManager {
         settings.addString("cmChannel", "");
         settings.addString("cmTemplate", "{user}: {message}");
         settings.addBoolean("cmHighlightedOnly", false);
-        
+
         settings.addBoolean("rulesAutoShow", true);
         settings.addList("rulesShown", new HashSet(), Setting.STRING);
-        
+
         //===============
         // Other Features
         //===============
-        
+
         // Livestreamer
         settings.addBoolean("livestreamer", false);
         settings.addString("livestreamerQualities", "Best, Worst, Select");
         settings.addString("livestreamerCommand", "livestreamer");
         settings.addBoolean("livestreamerUseAuth", false);
         settings.addBoolean("livestreamerShowDialog", true);
-        
+
         // Stream Highlights
         settings.addString("streamHighlightCommand", "!highlight");
         settings.addString("streamHighlightChannel", "");
         settings.addBoolean("streamHighlightChannelRespond", false);
-        
+
         // Stream Status Writer
         settings.addBoolean("enableStatusWriter", false);
         settings.addString("statusWriter", "");
-        
+
         // Auto-Unhost
         settings.addBoolean("autoUnhost", false);
-        settings.addList("autoUnhostStreams", new ArrayList(), Setting.STRING); 
+        settings.addList("autoUnhostStreams", new ArrayList(), Setting.STRING);
     }
     
     /**

--- a/src/chatty/gui/components/settings/LogSettings.java
+++ b/src/chatty/gui/components/settings/LogSettings.java
@@ -15,6 +15,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JCheckBox;
 
 /**
  *
@@ -135,7 +136,24 @@ public class LogSettings extends SettingsPanel {
         gbc.insets.bottom += 4;
         otherSettings.add(new JLabel("Folder:"), d.makeGbc(0, 0, 1, 1, GridBagConstraints.NORTHWEST));
         otherSettings.add(logPath, gbc);
-        
+
+        final Map<String,String> organizationOptions = new LinkedHashMap<>();
+        organizationOptions.put("never", "Never");
+        organizationOptions.put("daily", "Daily");
+        organizationOptions.put("weekly", "Weekly");
+        organizationOptions.put("monthly", "Monthly");
+        ComboStringSetting organizationCombo = new ComboStringSetting(organizationOptions);
+        organizationCombo.setEditable(false);
+        d.addStringSetting("logSplit", organizationCombo);
+
+        otherSettings.add(new JLabel("Split Logs:"), d.makeGbc(0, 1, 1, 1));
+        otherSettings.add(organizationCombo, d.makeGbc(1, 1, 1, 1, GridBagConstraints.WEST));
+
+        JCheckBox logSubdirectories = d.addSimpleBooleanSetting(
+            "logSubdirectories", "Subdirectories", "Organize logs into channel subdirectories."
+        );
+        otherSettings.add(logSubdirectories, d.makeGbcCloser(2, 1, 1, 1, GridBagConstraints.WEST));
+
         final Map<String,String> timestampOptions = new LinkedHashMap<>();
         addTimestampFormat(timestampOptions, "off");
         addTimestampFormat(timestampOptions, "[HH:mm:ss]");
@@ -147,9 +165,9 @@ public class LogSettings extends SettingsPanel {
         ComboStringSetting combo = new ComboStringSetting(timestampOptions);
         combo.setEditable(false);
         d.addStringSetting("logTimestamp", combo);
-        
-        otherSettings.add(new JLabel("Timestamp:"), d.makeGbc(0, 1, 1, 1));
-        otherSettings.add(combo, d.makeGbc(1, 1, 1, 1, GridBagConstraints.WEST));
+
+        otherSettings.add(new JLabel("Timestamp:"), d.makeGbc(0, 2, 1, 1));
+        otherSettings.add(combo, d.makeGbc(1, 2, 1, 1, GridBagConstraints.WEST));
         
         /**
          * Add panels to the dialog

--- a/src/chatty/gui/components/settings/SettingsDialog.java
+++ b/src/chatty/gui/components/settings/SettingsDialog.java
@@ -48,7 +48,7 @@ public class SettingsDialog extends JDialog implements ActionListener {
             "capitalizedNames", "correctlyCapitalizedNames", "ircv3CapitalizedNames",
             "tabOrder", "tabsMwheelScrolling", "inputFont",
             "bttvEmotes", "botNamesBTTV", "botNamesFFZ", "ffzEvent",
-            "logPath", "logTimestamp"
+            "logPath", "logTimestamp", "logSplit", "logSubdirectories"
     ));
     
     private final Set<String> reconnectRequiredDef = new HashSet<>(Arrays.asList(
@@ -99,7 +99,7 @@ public class SettingsDialog extends JDialog implements ActionListener {
     private static final String PANEL_COMPLETION = "Completion";
     private static final String PANEL_CHAT = "Chat";
     private static final String PANEL_NAMES = "Names";
-    
+
     private String currentlyShown;
     
     private final CardLayout cardManager;
@@ -176,7 +176,7 @@ public class SettingsDialog extends JDialog implements ActionListener {
         selection.setBorder(BorderFactory.createEtchedBorder());
 //        selection.setBackground(getBackground());
 //        selection.setForeground(getForeground());
-        
+
         gbc = makeGbc(0,0,1,1);
         gbc.insets = new Insets(10,10,10,3);
         gbc.fill = GridBagConstraints.BOTH;
@@ -211,7 +211,7 @@ public class SettingsDialog extends JDialog implements ActionListener {
         cards.add(new ChatSettings(this), PANEL_CHAT);
         nameSettings = new NameSettings(this);
         cards.add(nameSettings, PANEL_NAMES);
-        
+
         currentlyShown = PANEL_MAIN;
         selection.addListSelectionListener(new ListSelectionListener() {
 
@@ -507,8 +507,8 @@ public class SettingsDialog extends JDialog implements ActionListener {
         gbc.anchor = anchor;
         return gbc;
     }
-    
-        protected GridBagConstraints makeGbcSub(int x, int y, int w, int h, int anchor) {
+
+    protected GridBagConstraints makeGbcSub(int x, int y, int w, int h, int anchor) {
         GridBagConstraints gbc = new GridBagConstraints();
         gbc.gridx = x;
         gbc.gridy = y;
@@ -556,13 +556,6 @@ public class SettingsDialog extends JDialog implements ActionListener {
         return result;
     }
     
-//    protected JTextField addStringSetting(String name, int size, boolean editable) {
-//        JTextField result = new JTextField(size);
-//        result.setEditable(editable);
-//        stringSettings.put(name,result);
-//        return result;
-//   }
-    
     protected StringSetting addStringSetting(String settingName, StringSetting setting) {
         stringSettings.put(settingName, setting);
         return setting;
@@ -575,27 +568,6 @@ public class SettingsDialog extends JDialog implements ActionListener {
     }
     
     protected JPanel addEditorStringSetting(String settingName, int size, boolean editable, final String title, final boolean linebreaks, String info) {
-//        JPanel panel = new JPanel();
-//        ((FlowLayout)panel.getLayout()).setVgap(0);
-//        ((FlowLayout)panel.getLayout()).setHgap(2);
-//        final JTextField text = addSimpleStringSetting(settingName, size, editable);
-//        panel.add(text);
-//        JButton editButton = new JButton("Edit");
-//        editButton.setMargin(GuiUtil.SMALL_BUTTON_INSETS);
-//        panel.add(editButton);
-//        editButton.addActionListener(new ActionListener() {
-//
-//            @Override
-//            public void actionPerformed(ActionEvent e) {
-//                editor.setAllowEmpty(true);
-//                editor.setAllowLinebreaks(linebreaks);
-//                String result = editor.showDialog(title, text.getText());
-//                if (result != null) {
-//                    text.setText(result);
-//                }
-//            }
-//        });
-//        return panel;
         EditorStringSetting s = new EditorStringSetting(this, title, size, true, linebreaks, info);
         addStringSetting(settingName, s);
         return s;

--- a/src/chatty/util/chatlog/ChatLog.java
+++ b/src/chatty/util/chatlog/ChatLog.java
@@ -43,12 +43,14 @@ public class ChatLog {
     
     public ChatLog(Settings settings) {
         this.settings = settings;
-        
+
         Path path = getPath();
         if (path == null) {
             log = null;
         } else {
-            this.log = new LogManager(path);
+            String logSplit = settings.getString("logSplit");
+            Boolean logSubdirectories = settings.getBoolean("logSubdirectories");
+            this.log = new LogManager(path, logSplit, logSubdirectories);
         }
         compactForChannels = new HashMap<>();
         try {
@@ -122,7 +124,7 @@ public class ChatLog {
                     data.args.isEmpty() ? "" : " "+StringUtil.join(data.args, " ")));
         }
     }
-    
+
     public void viewerstats(String channel, ViewerStats stats) {
         if (isTypeEnabled("Viewerstats") && isEnabled(channel)) {
             if (stats != null && stats.isValid()) {
@@ -166,7 +168,7 @@ public class ChatLog {
         }
         compact(channel, "BAN", text);
     }
-    
+
     public void compact(String channel, String type, String info) {
         if (isEnabled(channel)) {
             if ((type.equals("MOD") || type.equals("UNMOD")) && isTypeEnabled("Mod")

--- a/src/chatty/util/chatlog/LogFile.java
+++ b/src/chatty/util/chatlog/LogFile.java
@@ -72,7 +72,7 @@ public class LogFile {
             if (i == 0) {
                 fileName = name + ".log";
             } else {
-                fileName = name + "_" + i + ".log";
+                fileName = name + "-" + i + ".log";
             }
 
             file = path.resolve(fileName);

--- a/src/chatty/util/chatlog/LogFile.java
+++ b/src/chatty/util/chatlog/LogFile.java
@@ -1,4 +1,3 @@
-
 package chatty.util.chatlog;
 
 import java.io.BufferedWriter;
@@ -8,87 +7,121 @@ import java.io.RandomAccessFile;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
-import java.nio.charset.Charset;
 import java.nio.file.Path;
+import java.util.Calendar;
 import java.util.logging.Logger;
 
 /**
  * Open, lock and write to a single logfile. The name of the logfiles is based
  * on the given name, but with ".log" added to the end.
- * 
+ *
  * @author tduva
  */
 public class LogFile {
-    
+
+    /**
+     * Debug logger.
+     */
     private static final Logger LOGGER = Logger.getLogger(LogFile.class.getName());
-    
+
+    /**
+     * Character set.
+     */
     private static final String CHARSET = "UTF-8";
-    
-    // How many different files to try to open in case of error
+
+    /**
+     * How many different files to try to open in case of error
+     */
     private static final int MAX_ATTEMPTS = 3;
-    
+
+    /**
+     * Write buffer for the LogFile instance.
+     */
     private BufferedWriter writer;
+
+    /**
+     * Rather or not we have a valid file. (eg. is writable)
+     */
     private boolean valid;
+
+    /**
+     * System path to where the file is stored.
+     */
     private Path file;
-    
+
+    /**
+     * The time this LogFile instance was created.
+     */
+    private Calendar currentTime;
+
+    /**
+     * LogFile constructor.
+     *
+     * @param path The system path of where the LogFile will be stored.
+     * @param name Name of the LogFile to be stored.
+     */
     private LogFile(Path path, String name) {
+        currentTime = Calendar.getInstance();
+
         // * can't be part of a filename (for Bouncer messages, e.g. *status)
         name = name.replace("*", "_");
-        for (int i=0;i<MAX_ATTEMPTS;i++) {
+
+        for (int i = 0; i < MAX_ATTEMPTS; i++) {
             String fileName;
+
             if (i == 0) {
-                fileName = name+".log";
+                fileName = name + ".log";
             } else {
-                fileName = name+"-"+i+".log";
+                fileName = name + "_" + i + ".log";
             }
+
             file = path.resolve(fileName);
+
             if (tryFile(file.toFile())) {
                 break;
             }
         }
     }
-    
+
     /**
-     * Creates a LogFile object for the given path and channel name.
-     * 
+     * Creates a LogFile object for the given path and name.
+     *
      * @param path The path where the file should be created under.
-     * @param channel The name of the channel, of which the filename is created.
-     * @return The LogFile or null if an error occured while opening the file.
+     * @param name The name of the log file to be created.
+     * @return The LogFile or null if an error occurred while opening the file.
      */
-    public static LogFile get(Path path, String channel) {
-        LogFile file = new LogFile(path, channel);
+    public static LogFile get(Path path, String name) {
+        LogFile file = new LogFile(path, name);
         if (file.valid) {
             return file;
         }
         return null;
     }
 
-    public Path getPath() {
-        return file;
-    }
-    
+    /**
+     * Attempt to write a new line to the LogFile.
+     *
+     * @param line The message to be written to the file.
+     * @return Returns true if the message is successfully logged.
+     */
     public boolean write(String line) {
-        //System.out.println("Writing "+line);
         if (!valid) {
-            LOGGER.warning("Log: Tried writing to invalid file "+file+"");
+            LOGGER.warning("Log: Tried writing to invalid file " + file + "");
             return false;
         }
+
         try {
             writer.write(line);
             writer.newLine();
             writer.flush();
             return true;
         } catch (IOException ex) {
-            LOGGER.warning("Log: Error writing to "+file+" ("+ex.getLocalizedMessage()+")");
+            LOGGER.warning("Log: Error writing to " + file + " (" + ex.getLocalizedMessage() + ")");
             close();
             return false;
         }
     }
-    
-    public boolean isValid() {
-        return valid;
-    }
-    
+
     /**
      * Properly close the file, which means it can't be used anymore.
      */
@@ -110,45 +143,61 @@ public class LogFile {
             LOGGER.warning("Log: Could not close " + file.toAbsolutePath() + " (" + ex.getLocalizedMessage() + ")");
         }
     }
-    
+
     /**
      * Tries to open the given file and obtain a lock on it. This may fail when
      * the file is already used by another process, or any other IOException of
      * course.
-     * 
-     * @param file
-     * @return 
+     *
+     * @param file The file to attempt to open.
+     * @return Returns true if the file is successfully opened and locked.
      */
     private boolean tryFile(File file) {
         try {
-            LOGGER.info("Log: Trying to open "+file.getAbsolutePath());
+            LOGGER.info("Log: Trying to open " + file.getAbsolutePath());
             RandomAccessFile raf = new RandomAccessFile(file, "rw");
             raf.seek(raf.length());
             FileChannel channel = raf.getChannel();
             FileLock lock = channel.tryLock();
+
             if (lock != null) {
                 writer = new BufferedWriter(Channels.newWriter(channel, CHARSET));
                 valid = true;
+
                 return true;
             }
         } catch (IOException ex) {
-            LOGGER.warning("Log: Lock failed ("+file+" / "+ex+")");
+            LOGGER.warning("Log: Lock failed (" + file + " / " + ex + ")");
         }
-        LOGGER.warning("Log: Lock failed ("+file+")");
+
+        LOGGER.warning("Log: Lock failed (" + file + ")");
         return false;
     }
-    
-//    private void openFile(Path file) {
-//        try {
-//            writer = Files.newBufferedWriter(file, CHARSET,
-//                    StandardOpenOption.APPEND, StandardOpenOption.CREATE);
-//            valid = true;
-//            this.file = file;
-//            LOGGER.info("Log: File "+file.toAbsolutePath()+" opened.");
-//        } catch (IOException ex) {
-//            LOGGER.warning("Log: Error opening file "+file+" ("+ex.getLocalizedMessage()+")");
-//        }
-//    }
-    
-    
+
+    /**
+     * Getter for the `valid` property.
+     *
+     * @return The `valid` property.
+     */
+    public boolean isValid() {
+        return valid;
+    }
+
+    /**
+     * Getter for the path of the LogFile.
+     *
+     * @return The `file` property.
+     */
+    public Path getPath() {
+        return file;
+    }
+
+    /**
+     * Getter for the date that this LogFile instance was created.
+     *
+     * @return The `currentTime` property.
+     */
+    public Calendar getDate() {
+        return currentTime;
+    }
 }

--- a/src/chatty/util/chatlog/LogManager.java
+++ b/src/chatty/util/chatlog/LogManager.java
@@ -22,17 +22,17 @@ public class LogManager {
     private static final int MAX_WAIT = 10*1000;
     
     private final AtomicInteger errors = new AtomicInteger();
-    
+
     private final BlockingQueue<LogItem> queue;
     private final Thread writerThread;
-    
-    public LogManager(Path path) {
+
+    public LogManager(Path path, String splitLogs, Boolean useSubdirectories) {
         path.toFile().mkdirs();
         if (!path.toFile().exists()) {
             LOGGER.warning("Log: Failed to create path: "+path);
         }
         this.queue = new LinkedBlockingQueue<>(QUEUE_CAPACITY);
-        this.writerThread = new Thread(new LogWriter(queue, path));
+        this.writerThread = new Thread(new LogWriter(queue, path, splitLogs, useSubdirectories));
     }
     
     public void start() {


### PR DESCRIPTION
This PR adds the ability to automatically split log files and group them into subdirectories.

Log files can be split daily, weekly, or monthly and will be prefixed with a date stamp `yyyy-MM-dd_`.
<small>(Note: Weekly and monthly log splits will be dated as the first day of that week or month, respectively. Not the day that the file was created.)</small>

The subdirectories option will organize logs into channel subdirectories such that all logs from `#mheetu` will be located in `logs/#mheetu/yyyy-MM-dd_#mheetu.log`.

Settings screen:
![20164806-104831](https://cloud.githubusercontent.com/assets/8495484/13531905/e0d0d57c-e1f6-11e5-8691-b0a92b47ccee.png)

Also cleaned up and added some docblocks to `LogFile`.
