### PR TITLE
Add some very large font size choices.

### DIFF
--- a/src/chatty/gui/components/settings/FontChooser.java
+++ b/src/chatty/gui/components/settings/FontChooser.java
@@ -52,7 +52,7 @@ public class FontChooser extends JDialog implements InputListListener,
     private static final int FALLBACK_FONT_SIZE = 14;
     private String[] fontSizes = new String[]{
         "8", "9", "10", "11", "12", "13", "14", "15", "16", "18", "20", "22",
-        "24", "26", "28", "30", "32"
+        "24", "26", "28", "30", "32", "36", "48", "60", "72"
     };
     
     // Reference


### PR DESCRIPTION
For smaller screens with high resolutions, the font sizes available aren't quite big enough for some use cases; In particular, when using chatty on a second (smaller but still high-res) screen while full-screening the stream or game on the main display.

I built and tried this with the bigger font sizes and it works great; I plan to use it to stream tonight.

PS - Thanks for making this!