### PR TITLE
Fix Clip not closing after playback in util/Sound.java

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ build/
 dist/
 nbproject/
 working_directory/
+out/
+chatty.iml
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ working_directory/
 out/
 chatty.iml
 .idea/
+META-INF/

--- a/src/chatty/util/Sound.java
+++ b/src/chatty/util/Sound.java
@@ -60,6 +60,13 @@ public class Sound {
                 volumeInfo = "no volume control";
             }
             
+            clip.addLineListener(
+                listener -> {
+                    if (listener.getType() == LineEvent.Type.STOP)
+                        clip.close();
+                }
+            );
+            
             clip.start();
             LOGGER.info("Playing sound "+id+"/"+fileName+" ("+volumeInfo+")");
         } catch (NullPointerException | LineUnavailableException | IOException | UnsupportedAudioFileException ex) {


### PR DESCRIPTION
Close the Clip after playback has finished to prevent like one million "ALSA plug-in [java]" entries in the ALSA and/or PulseAudio mixer under Linux and other UNIX-like Operating Systems.

The fix was very simple.
I just added a LineListener to the Clip.

![](https://cloud.githubusercontent.com/assets/13280758/14066854/bb18f6a4-f455-11e5-90e7-c1d6ba46ee61.png)