### PR TITLE
Add StreamChat option to context menu

### DIFF
--- a/src/chatty/gui/MainGui.java
+++ b/src/chatty/gui/MainGui.java
@@ -1577,13 +1577,13 @@ public class MainGui extends JFrame implements Runnable {
                 firstStream = streams.iterator().next();
             }
             if (cmd.equals("stream") || cmd.equals("streamPopout")
-                    || cmd.equals("streamPopoutOld") || cmd.equals("profile")) {
+                    || cmd.equals("streamPopoutOld") || cmd.equals("streamChat") || cmd.equals("profile")) {
                 List<String> urls = new ArrayList<>();
                 for (String stream : streams) {
                     String url;
                     switch (cmd) {
                         case "stream":
-                            url = TwitchUrl.makeTwitchStreamUrl(stream, false);
+                            url = TwitchUrl.makeTwitchStreamUrl(stream, null);
                             break;
                         case "profile":
                             url = TwitchUrl.makeTwitchProfileUrl(stream);
@@ -1591,9 +1591,11 @@ public class MainGui extends JFrame implements Runnable {
                         case "streamPopout":
                             url = TwitchUrl.makeTwitchPlayerUrl(stream);
                             break;
-                        default:
-                            url = TwitchUrl.makeTwitchStreamUrl(stream, true);
+                        case "streamChat":
+                            url = TwitchUrl.makeTwitchStreamUrl(stream, "chat");
                             break;
+                        default:
+                            url = TwitchUrl.makeTwitchStreamUrl(stream, null);
                     }
                     urls.add(url);
                 }

--- a/src/chatty/gui/TwitchUrl.java
+++ b/src/chatty/gui/TwitchUrl.java
@@ -44,7 +44,7 @@ public class TwitchUrl {
             JOptionPane.showMessageDialog(parent, "Unable to open Twitch Stream URL (Not on a channel)",
                     "Info", JOptionPane.INFORMATION_MESSAGE);
         } else {
-            String url = makeTwitchStreamUrl(nick, popout);
+            String url = makeTwitchStreamUrl(nick, popout ? "popout" : null);
             UrlOpener.openUrlPrompt(parent, url);
         }
     }
@@ -52,11 +52,11 @@ public class TwitchUrl {
     public static String makeTwitchProfileUrl(String channel) {
         return "http://twitch.tv/" + channel.toLowerCase() + "/profile";
     }
-    
-    public static String makeTwitchStreamUrl(String channel, boolean popout) {
+
+    public static String makeTwitchStreamUrl(String channel, String action) {
         String url = "http://twitch.tv/" + channel.toLowerCase() + "";
-        if (popout) {
-            url += "/popout";
+        if ((action != null) && !action.isEmpty()) {
+            url += "/" + action;
         }
         return url;
     }

--- a/src/chatty/gui/components/menus/ContextMenuHelper.java
+++ b/src/chatty/gui/components/menus/ContextMenuHelper.java
@@ -71,6 +71,7 @@ public class ContextMenuHelper {
         m.addItem("stream", "Normal", streamSubmenu);
         m.addItem("streamPopout", "Popout", streamSubmenu);
         m.addItem("streamPopoutOld", "Popout (Old)", streamSubmenu);
+        m.addItem("streamChat", "Chat", streamSubmenu);
         m.addItem("streamsMultitwitchtv", "Multitwitch.tv", streamSubmenu);
         m.addItem("streamsSpeedruntv", "Speedrun.tv", streamSubmenu);
         m.addItem("streamsKadgar", "Kadgar.net", streamSubmenu);


### PR DESCRIPTION
Add an option to open only chat URL to stream context menu.

This is very useful when we use livestreamer.exe to open the stream in one window; the other window is used for viewing twitch chat.
