### PR TITLE
fixes bttv emotes ending on : to not appear in text 

### DIFF
--- a/src/chatty/util/api/Emoticon.java
+++ b/src/chatty/util/api/Emoticon.java
@@ -55,7 +55,7 @@ public class Emoticon {
         FEATURE_FRIDAY, EVENT, CHEER
     }
     
-    private static final Pattern NOT_WORD = Pattern.compile("[^\\w]");
+    private static final Pattern NOT_WORD = Pattern.compile("[^\\w|:]");
     
     /**
      * Try loading the image these many times, which will be tried if an error


### PR DESCRIPTION
Currently when you write a text containing emotes ending on ":", they will always be replaced with the emote which can be annoying. E.g. "D:D" or "ID: xy" will turn into "Bttv-Emote D: + D" and "I + Emote + xy".  Emotes that i know which are affected are the Bttv-globals D: and :tf: 

This fixed this issue by adding the word boundaries, even if ":" is found. So ":" will be an exception of non-word characters.