### PR TITLE
Custom notification command

### DIFF
--- a/src/chatty/SettingsManager.java
+++ b/src/chatty/SettingsManager.java
@@ -409,6 +409,7 @@ public class SettingsManager {
         settings.addLong("nMaxQueueSize", 4);
         settings.addBoolean("nActivity", false);
         settings.addLong("nActivityTime", 10);
+        settings.addString("nCommand", "");
 
         settings.addList("notifications", getDefaultNotificationSettingValue(), Setting.LIST);
         settings.addList("nColorPresets", new ArrayList<>(), Setting.LIST);

--- a/src/chatty/gui/MainGui.java
+++ b/src/chatty/gui/MainGui.java
@@ -4055,7 +4055,7 @@ public class MainGui extends JFrame implements Runnable {
             }
             Set<String> notificationSettings = new HashSet<>(Arrays.asList(
                 "nScreen", "nPosition", "nDisplayTime", "nMaxDisplayTime",
-                "nMaxDisplayed", "nMaxQueueSize", "nActivity", "nActivityTime"));
+                "nMaxDisplayed", "nMaxQueueSize", "nActivity", "nActivityTime", "nCommand"));
             if (notificationSettings.contains(setting)) {
                 updateNotificationSettings();
             }

--- a/src/chatty/gui/MainGui.java
+++ b/src/chatty/gui/MainGui.java
@@ -2485,9 +2485,9 @@ public class MainGui extends JFrame implements Runnable {
             CustomCommand command = CustomCommand.parse(client.settings.getString("nCommand"));
 
             Parameters param = Parameters.create("");
-            param.put("title", "\"" + title + "\"");
-            param.put("message", "\"" + message + "\"");
-            param.put("channel", "\"" + channel + "\"");
+            param.put("title", title);
+            param.put("message", message);
+            param.put("channel", channel);
 
             ProcessManager.execute(command.replace(param), "Notification");
         }

--- a/src/chatty/gui/MainGui.java
+++ b/src/chatty/gui/MainGui.java
@@ -74,6 +74,7 @@ import chatty.util.api.TwitchApi.RequestResultCode;
 import chatty.util.api.pubsub.ModeratorActionData;
 import chatty.util.commands.CustomCommand;
 import chatty.util.commands.Parameters;
+import chatty.util.commands.Parser;
 import chatty.util.hotkeys.HotkeyManager;
 import chatty.util.settings.Setting;
 import chatty.util.settings.SettingChangeListener;
@@ -2484,8 +2485,33 @@ public class MainGui extends JFrame implements Runnable {
     public void showNotification(String title, String message, Color foreground, Color background, String channel) {
         if (client.settings.getLong("nType") == NotificationSettings.NOTIFICATION_TYPE_CUSTOM) {
             notificationWindowManager.showMessage(title, message, foreground, background, channel);
-        } else {
+        } else if(client.settings.getLong("nType") == NotificationSettings.NOTIFICATION_TYPE_TRAY) {
             trayIcon.displayInfo(title, message);
+        } else {
+            String[] commandParams = client.settings.getString("nCommand").split(" ");
+
+            for(int i = 0; i < commandParams.length; i++) {
+                switch(commandParams[i]) {
+                    case "$(title)":
+                        commandParams[i] = title;
+                        break;
+                    case "$(message)":
+                        commandParams[i] = message;
+                        break;
+                    case "$(channel)":
+                        commandParams[i] = channel;
+                        break;
+                }
+            }
+
+            try {
+                ProcessBuilder p = new ProcessBuilder();
+
+                p.command(commandParams);
+                p.start();
+            } catch(java.io.IOException exception) {
+                exception.printStackTrace();
+            }
         }
     }
     

--- a/src/chatty/gui/MainGui.java
+++ b/src/chatty/gui/MainGui.java
@@ -15,6 +15,7 @@ import chatty.gui.components.Channel;
 import chatty.gui.components.TokenGetDialog;
 import chatty.gui.components.FavoritesDialog;
 import chatty.gui.components.JoinDialog;
+import chatty.util.*;
 import chatty.util.api.Emoticon;
 import chatty.util.api.StreamInfo;
 import chatty.util.api.TokenInfo;
@@ -57,13 +58,6 @@ import chatty.gui.notifications.Notification;
 import chatty.gui.notifications.NotificationActionListener;
 import chatty.gui.notifications.NotificationManager;
 import chatty.gui.notifications.NotificationWindowManager;
-import chatty.util.CopyMessages;
-import chatty.util.DateTime;
-import chatty.util.ImageCache;
-import chatty.util.MiscUtil;
-import chatty.util.MsgTags;
-import chatty.util.Sound;
-import chatty.util.StringUtil;
 import chatty.util.api.ChatInfo;
 import chatty.util.api.CheerEmoticon;
 import chatty.util.api.Emoticon.EmoticonImage;
@@ -2488,30 +2482,14 @@ public class MainGui extends JFrame implements Runnable {
         } else if(client.settings.getLong("nType") == NotificationSettings.NOTIFICATION_TYPE_TRAY) {
             trayIcon.displayInfo(title, message);
         } else {
-            String[] commandParams = client.settings.getString("nCommand").split(" ");
+            CustomCommand command = CustomCommand.parse(client.settings.getString("nCommand"));
 
-            for(int i = 0; i < commandParams.length; i++) {
-                switch(commandParams[i]) {
-                    case "$(title)":
-                        commandParams[i] = title;
-                        break;
-                    case "$(message)":
-                        commandParams[i] = message;
-                        break;
-                    case "$(channel)":
-                        commandParams[i] = channel;
-                        break;
-                }
-            }
+            Parameters param = Parameters.create("");
+            param.put("title", "\"" + title + "\"");
+            param.put("message", "\"" + message + "\"");
+            param.put("channel", "\"" + channel + "\"");
 
-            try {
-                ProcessBuilder p = new ProcessBuilder();
-
-                p.command(commandParams);
-                p.start();
-            } catch(java.io.IOException exception) {
-                exception.printStackTrace();
-            }
+            ProcessManager.execute(command.replace(param), "Notification");
         }
     }
     

--- a/src/chatty/gui/components/settings/NotificationSettings.java
+++ b/src/chatty/gui/components/settings/NotificationSettings.java
@@ -259,13 +259,14 @@ public class NotificationSettings extends SettingsPanel {
     
     private void updateSettingsState() {
         boolean enabled = nType.getSettingValue().equals(Long.valueOf(0));
+        boolean cmdEnabled = nType.getSettingValue().equals(Long.valueOf(2));
+
         nPosition.setEnabled(enabled);
         nScreen.setEnabled(enabled);
         nDisplayTime.setEnabled(enabled);
         nMaxDisplayTime.setEnabled(enabled);
         userActivity.setEnabled(enabled);
-
-
+        nCommand.setEnabled(cmdEnabled);
     }
     
     protected void setData(List<Notification> data) {

--- a/src/chatty/gui/components/settings/NotificationSettings.java
+++ b/src/chatty/gui/components/settings/NotificationSettings.java
@@ -24,12 +24,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JTabbedPane;
+import javax.swing.*;
 
 /**
  *
@@ -39,7 +34,8 @@ public class NotificationSettings extends SettingsPanel {
     
     public final static long NOTIFICATION_TYPE_CUSTOM = 0;
     public final static long NOTIFICATION_TYPE_TRAY = 1;
-    
+    public final static long NOTIFICATION_TYPE_COMMAND = 2;
+
     private final LinkLabel userReadPermission;
     private final JCheckBox requestFollowedStreams;
     
@@ -49,6 +45,7 @@ public class NotificationSettings extends SettingsPanel {
     private final DurationSetting nDisplayTime;
     private final DurationSetting nMaxDisplayTime;
     private final JCheckBox userActivity;
+    private final JTextField nCommand;
     
     private final PathSetting soundsPath;
     
@@ -73,6 +70,7 @@ public class NotificationSettings extends SettingsPanel {
         Map<Long, String> nTypeOptions = new LinkedHashMap<>();
         nTypeOptions.put(NOTIFICATION_TYPE_CUSTOM, "Chatty Notifications");
         nTypeOptions.put(NOTIFICATION_TYPE_TRAY, "Tray Notifications (OS dependant)");
+        nTypeOptions.put(NOTIFICATION_TYPE_COMMAND, "Run Command");
         nType = new ComboLongSetting(nTypeOptions);
 
         nType.addItemListener(new ItemListener() {
@@ -132,7 +130,10 @@ public class NotificationSettings extends SettingsPanel {
         d.addLongSetting("nMaxDisplayTime", nMaxDisplayTime);
         notificationSettings.add(nMaxDisplayTime,
                 d.makeGbc(3, 2, 1, 1, GridBagConstraints.WEST));
-        
+
+        nCommand = d.addSimpleStringSetting("nCommand", 50, true);
+        notificationSettings.add(nCommand, d.makeGbc(1, 4, 1, 1, GridBagConstraints.EAST));
+
         //================
         // Sound Settings
         //================
@@ -263,6 +264,8 @@ public class NotificationSettings extends SettingsPanel {
         nDisplayTime.setEnabled(enabled);
         nMaxDisplayTime.setEnabled(enabled);
         userActivity.setEnabled(enabled);
+
+
     }
     
     protected void setData(List<Notification> data) {

--- a/src/chatty/gui/components/settings/NotificationSettings.java
+++ b/src/chatty/gui/components/settings/NotificationSettings.java
@@ -133,7 +133,7 @@ public class NotificationSettings extends SettingsPanel {
 
         notificationSettings.add(new JLabel("Command:"), d.makeGbc(0, 4, 1, 1, GridBagConstraints.EAST));
 
-        nCommand = d.addSimpleStringSetting("nCommand", 50, true);
+        nCommand = d.addSimpleStringSetting("nCommand", 35, true);
         notificationSettings.add(nCommand, d.makeGbc(1, 4, 1, 1, GridBagConstraints.WEST));
 
         notificationSettings.add(new JLabel("Tip: Add quotes around variables, as they may contain spaces."), d.makeGbc(1, 6, 1, 1, GridBagConstraints.WEST));

--- a/src/chatty/gui/components/settings/NotificationSettings.java
+++ b/src/chatty/gui/components/settings/NotificationSettings.java
@@ -93,7 +93,7 @@ public class NotificationSettings extends SettingsPanel {
         nPositionOptions.put(Long.valueOf(3), "Bottom-Right");
         nPosition = new ComboLongSetting(nPositionOptions);
         d.addLongSetting("nPosition", nPosition);
-        gbc = d.makeGbc(1, 1, 1, 1);
+        gbc = d.makeGbc(1, 1, 1, 1, GridBagConstraints.WEST);
         notificationSettings.add(nPosition, gbc);
         
         notificationSettings.add(new JLabel("Screen:"),
@@ -131,8 +131,12 @@ public class NotificationSettings extends SettingsPanel {
         notificationSettings.add(nMaxDisplayTime,
                 d.makeGbc(3, 2, 1, 1, GridBagConstraints.WEST));
 
+        notificationSettings.add(new JLabel("Command:"), d.makeGbc(0, 4, 1, 1, GridBagConstraints.EAST));
+
         nCommand = d.addSimpleStringSetting("nCommand", 50, true);
-        notificationSettings.add(nCommand, d.makeGbc(1, 4, 1, 1, GridBagConstraints.EAST));
+        notificationSettings.add(nCommand, d.makeGbc(1, 4, 1, 1, GridBagConstraints.WEST));
+
+        notificationSettings.add(new JLabel("Tip: Add quotes around variables, as they may contain spaces."), d.makeGbc(1, 6, 1, 1, GridBagConstraints.WEST));
 
         //================
         // Sound Settings


### PR DESCRIPTION
Chatty doesn't have native linux notifications, but in #26 someone suggested that there should be a way to run external commands for notifications, so I created a PR for this functionality:

![screenshot_20170923_192214](https://user-images.githubusercontent.com/2244285/30778079-a159ad62-a0bb-11e7-9afc-404ea434ab38.png)
_(This screenshot is from KDE Plasma using notify-send)_

This PR adds the ability to use a external command for notifications instead of the current two methods (one of which doesn't work on linux at all). It supports very simple substitution, for example:

![screenshot_20170923_200351](https://user-images.githubusercontent.com/2244285/30778088-e1eab5c4-a0bb-11e7-850a-947b800d67ab.png)

How the command text is being substituted is a little wonky, but testers and suggestions welcome!
