### PR TITLE
Made some methods from SettingsManager public

### DIFF
--- a/src/chatty/SettingsManager.java
+++ b/src/chatty/SettingsManager.java
@@ -61,7 +61,7 @@ public class SettingsManager {
     /**
      * Defines what settings there are and their default values.
      */
-    void defineSettings() {
+    public void defineSettings() {
         
         // Additional files (in addition to the default file)
         String loginFile = Chatty.getUserDataDirectory()+"login";
@@ -561,7 +561,7 @@ public class SettingsManager {
     /**
      * Tries to load the settings from file.
      */
-    void loadSettingsFromFile() {
+    public void loadSettingsFromFile() {
         settings.loadSettingsFromJson();
     }
     
@@ -570,7 +570,7 @@ public class SettingsManager {
      * performed in (seconds). The backup manager will decide whether to
      * actually make a backup.
      */
-    void backupFiles() {
+    public void backupFiles() {
         long backupDelay = DateTime.DAY * settings.getLong("backupDelay");
         backup.performBackup((int)backupDelay, (int)settings.getLong("backupCount"));
     }
@@ -583,7 +583,7 @@ public class SettingsManager {
      * 
      * @param args Map with commandline settings, key=value pairs
      */
-    void loadCommandLineSettings(Map<String, String> args) {
+    public void loadCommandLineSettings(Map<String, String> args) {
         for (String key : args.keySet()) {
             // Go through all commandline options
             String value = args.get(key);
@@ -637,7 +637,7 @@ public class SettingsManager {
     /**
      * Override some now unused settings or change settings on version change.
      */
-    void overrideSettings() {
+    public void overrideSettings() {
         settings.setBoolean("ignoreJoinsParts", false);
         if (updatedFromBefore("0.7.2")) {
             String value = settings.getString("timeoutButtons");


### PR DESCRIPTION
As I use Chatty in a project of mine, I use the settings manager and it's methods. It would be nice, if these methods would be public upstream. I do not see a reason not to make them public :)