### PR TITLE
Fix typo in TwitchConnection.ConnectionListener

### DIFF
--- a/src/chatty/TwitchConnection.java
+++ b/src/chatty/TwitchConnection.java
@@ -1276,7 +1276,7 @@ public class TwitchConnection {
 
         void onJoinAttempt(String channel);
 
-        void onChannelJoined(User channel);
+        void onChannelJoined(User user);
 
         void onChannelLeft(String channel);
 


### PR DESCRIPTION
User channel -> User user
I guess that speaks for itself.