### PR TITLE
Adds a !window option to highlights to prevent them appearing in the …

### DIFF
--- a/src/chatty/gui/Highlighter.java
+++ b/src/chatty/gui/Highlighter.java
@@ -34,6 +34,7 @@ public class Highlighter {
     private Color lastMatchColor;
     private boolean lastMatchNoNotification;
     private boolean lastMatchNoSound;
+    private boolean lastMatchNoWindow;
     
     // Settings
     private boolean highlightUsername;
@@ -115,6 +116,10 @@ public class Highlighter {
         return lastMatchNoSound;
     }
     
+    public boolean getLastMatchNoWindow() {
+        return lastMatchNoWindow;
+    }
+    
     /**
      * Checks whether the given message consisting of username and text should
      * be highlighted.
@@ -128,6 +133,7 @@ public class Highlighter {
         lastMatchColor = null;
         lastMatchNoNotification = false;
         lastMatchNoSound = false;
+        lastMatchNoWindow = false;
         
         String lowercaseText = text.toLowerCase();
         
@@ -143,6 +149,7 @@ public class Highlighter {
                 lastMatchColor = item.getColor();
                 lastMatchNoNotification = item.noNotification();
                 lastMatchNoSound = item.noSound();
+                lastMatchNoWindow = item.noWindow();
                 return true;
             }
         }
@@ -209,6 +216,7 @@ public class Highlighter {
         private Color color;
         private boolean noNotification;
         private boolean noSound;
+        private boolean noWindow;
         private boolean appliesToInfo;
         
         private boolean error;
@@ -347,6 +355,8 @@ public class Highlighter {
                             noSound = true;
                         } else if (part.equals("!notify")) {
                             noNotification = true;
+                        } else if (part.equals("!window")) {
+                            noWindow = true;
                         } else if (part.equals("info")) {
                             appliesToInfo = true;
                         }
@@ -541,6 +551,10 @@ public class Highlighter {
         
         public boolean noSound() {
             return noSound;
+        }
+        
+        public boolean noWindow() {
+            return noWindow;
         }
         
         public boolean hasError() {

--- a/src/chatty/gui/MainGui.java
+++ b/src/chatty/gui/MainGui.java
@@ -2632,8 +2632,10 @@ public class MainGui extends JFrame implements Runnable {
                 
                 // Do stuff if highlighted, without printing message
                 if (highlighted) {
-                    highlightedMessages.addMessage(channel, user, text, action,
-                            tagEmotes, bits, whisper);
+                    if (!highlighter.getLastMatchNoWindow()) {
+                        highlightedMessages.addMessage(channel, user, text, action,
+                                tagEmotes, bits, whisper);
+                    }
                     if (!highlighter.getLastMatchNoNotification()) {
                         channels.setChannelHighlighted(chan);
                     } else {

--- a/src/chatty/gui/components/help/help-settings.html
+++ b/src/chatty/gui/components/help/help-settings.html
@@ -733,6 +733,7 @@
             <ul>
                 <li><code>silent</code> - Disable sounds for this item</li>
                 <li><code>!notify</code> - Disable notifications for this item</li>
+                <li><code>!window</code> - Disable copying this item to the Highlighted Messages Window</li>
                 <li><code>info</code> - This item applies to info messages instead
                 of regular user messages (works only for Ignoring messages at the
                 moment)</li>


### PR DESCRIPTION
…"Highlighted Messages" window, e.g. use alongside !notify to use the highlight system to colorize certain messages without treating them as a highlight.

My personal use case is to use darker text for bots without ignoring them entirely. Making them less visually noisy allows me to focus my attention on chatting, but leaves bot messages for when I care about the content.