### PR TITLE
Added buttons to download updates directly.

### DIFF
--- a/src/chatty/gui/components/UpdateMessage.java
+++ b/src/chatty/gui/components/UpdateMessage.java
@@ -4,12 +4,14 @@ package chatty.gui.components;
 import chatty.Chatty;
 import chatty.gui.UrlOpener;
 import chatty.util.UrlRequest;
+import chatty.util.MiscUtil;
 import java.awt.BorderLayout;
 import java.awt.Font;
 import java.awt.Insets;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import javax.swing.JComponent;
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
@@ -27,10 +29,14 @@ public class UpdateMessage extends JDialog {
     
     private static final String CHANGELOG_URL = "http://chatty.github.io/changes.txt";
     //private static final String CHANGELOG_URL = "http://127.0.0.1/twitch/changes.txt";
+
+    private static final String RELEASES_URL = "https://github.com/chatty/chatty/releases/download/v";
     
     private final JLabel version;
     private final JTextArea changelog;
     private boolean changelogLoaded;
+    private String newVersion;
+
     
     public UpdateMessage(Window owner) {
         super(owner);
@@ -64,11 +70,44 @@ public class UpdateMessage extends JDialog {
                     UrlOpener.openUrlPrompt(UpdateMessage.this, Chatty.WEBSITE, true);
                 } else if (e.getSource() == close) {
                     setVisible(false);
+                } else {
+                    //https://github.com/chatty/chatty/releases/download/v0.9/Chatty_0.9_hotkey_32bit.zip
+                    String url = String.format(RELEASES_URL + "%1$s/Chatty_%1$s%2$s.zip", newVersion, ((JComponent) e.getSource()).getName());
+                    UrlOpener.openUrlPrompt(UpdateMessage.this, url, true);
                 }
+
             }
         };
         openWebsite.addActionListener(buttonAction);
         close.addActionListener(buttonAction);
+
+        final JButton latest = new JButton("Download latest");
+        latest.setName("");
+        latest.addActionListener(buttonAction);
+
+        if (MiscUtil.OS_WINDOWS) {
+            final JLabel downloads = new JLabel("Downloads: ");
+            latest.setText("Standard");
+            final JButton hotkey32 = new JButton("Global hotkey (32-bit)");
+            final JButton hotkey64 = new JButton("Global hotkey (64-bit)");
+            final JButton standalone = new JButton("Standalone");
+
+            hotkey32.setName("_hotkey_32bit");
+            hotkey64.setName("_hotkey_64bit");
+            standalone.setName("_windows_standalone");
+
+            buttons.add(downloads);
+            buttons.add(latest);
+            buttons.add(hotkey32);
+            buttons.add(hotkey64);
+            buttons.add(standalone);
+
+            hotkey32.addActionListener(buttonAction);
+            hotkey64.addActionListener(buttonAction);
+            standalone.addActionListener(buttonAction);
+        } else {
+            buttons.add(latest);
+        }
         
         pack();
     }
@@ -80,6 +119,7 @@ public class UpdateMessage extends JDialog {
     }
     
     public void setNewVersion(String newVersion) {
+        this.newVersion = newVersion;
         version.setText("<html><body style='padding: 6px;'>Your version: "+Chatty.VERSION+" | Latest: "+newVersion);
     }
     


### PR DESCRIPTION
Added buttons to download updates directly.
I see it quite useful. Why users have to go to the website if they see full changelogs in dialog and can download needed version from same place?
This is in Windows:
![image](https://user-images.githubusercontent.com/4051126/34656295-8cc0dcfc-f428-11e7-954f-297caf95ab18.png)


Linux:
![image](https://user-images.githubusercontent.com/4051126/34656282-60cc6b8e-f428-11e7-9954-c1600f861f70.png)

