### PR TITLE
Allow /join command takes multiple channel names, separate by space

### DIFF
--- a/src/chatty/TwitchClient.java
+++ b/src/chatty/TwitchClient.java
@@ -1483,7 +1483,7 @@ public class TwitchClient {
             g.printLine("A channel to join needs to be specified.");
         } else {
             String[] channelList = channelString.split(" ");
-            for( String channel: channelList)
+            for (String channel: channelList)
             {
                 channel = StringUtil.toLowerCase(channel.trim());
                 c.joinChannel(channel);

--- a/src/chatty/TwitchClient.java
+++ b/src/chatty/TwitchClient.java
@@ -1478,12 +1478,17 @@ public class TwitchClient {
      * 
      * @param channel 
      */
-    public void commandJoinChannel(String channel) {
-        if (channel == null) {
+    public void commandJoinChannel(String channelString) {
+        if (channelString == null) {
             g.printLine("A channel to join needs to be specified.");
         } else {
-            channel = StringUtil.toLowerCase(channel.trim());
-            c.joinChannel(channel);
+            String[] channelList = channelString.split(" ");
+            for( String channel: channelList)
+            {
+                channel = StringUtil.toLowerCase(channel.trim());
+                c.joinChannel(channel);
+            }
+            
         }
     }
     


### PR DESCRIPTION
Hi all,

This is a patch for issue #263 .
With this patch, user can use command like
`/join harnaisxsumire666 inkiiing julia_lion`
to join multiple channels with only one command.

Hinet60613 :)