### PR TITLE
Add help information about usercolor filters for $globalmod and $anymod

### DIFF
--- a/src/chatty/gui/components/help/help-settings.html
+++ b/src/chatty/gui/components/help/help-settings.html
@@ -138,6 +138,8 @@
         <li><code>$turbo</code> - Turbo Users</li>
         <li><code>$admin</code> - Admins</li>
         <li><code>$staff</code> - Staff members</li>
+        <li><code>$globalmod</code> - Global Moderators</li>
+        <li><code>$anymod</code> - All Admins, Broadcasters, Global Moderators, Moderators and Staff members</li>
         <li><code>$all</code> - All users, this can be used to specify a default
         color (should be put at the very end of the list)</li>
         <li><code>$broadcaster</code> - Broadcasters</li>


### PR DESCRIPTION
Information about the usercolor filters `$globalmod` and `$anymod` was missing.
This led to questions/feature requests like #281.

Fix #281