### PR TITLE
Add a space after every auto complete

### DIFF
--- a/src/chatty/gui/components/AutoCompletion.java
+++ b/src/chatty/gui/components/AutoCompletion.java
@@ -366,7 +366,7 @@ public class AutoCompletion {
         }
 
         // Get the replacement value for this completion step
-        String nick = items.get(index);
+        String nick = items.get(index) + " ";
 
         //---------------
         // Common prefix


### PR DESCRIPTION
Add a space after every auto complete, just as BetterTTV autocomplete works.
I realized i was not able to do a fast emote auto completion as i was used to do in BetterTTV browser extension, so i made this small tweak, tested and working.