### PR TITLE
Removed full package path of List class in MainGui.

### DIFF
--- a/src/chatty/gui/MainGui.java
+++ b/src/chatty/gui/MainGui.java
@@ -2105,23 +2105,23 @@ public class MainGui extends JFrame implements Runnable {
         return userListener;
     }
     
-    public java.util.List<UsercolorItem> getUsercolorData() {
+    public List<UsercolorItem> getUsercolorData() {
         return client.usercolorManager.getData();
     }
 
-    public void setUsercolorData(java.util.List<UsercolorItem> data) {
+    public void setUsercolorData(List<UsercolorItem> data) {
         client.usercolorManager.setData(data);
     }
     
-    public java.util.List<MsgColorItem> getMsgColorData() {
+    public List<MsgColorItem> getMsgColorData() {
         return msgColorManager.getData();
     }
     
-    public void setMsgColorData(java.util.List<MsgColorItem> data) {
+    public void setMsgColorData(List<MsgColorItem> data) {
         msgColorManager.setData(data);
     }
     
-    public java.util.List<Usericon> getUsericonData() {
+    public List<Usericon> getUsericonData() {
         return client.usericonManager.getCustomData();
     }
     
@@ -2129,15 +2129,15 @@ public class MainGui extends JFrame implements Runnable {
         return client.usericonManager.getTwitchBadgeTypes();
     }
     
-    public void setUsericonData(java.util.List<Usericon> data) {
+    public void setUsericonData(List<Usericon> data) {
         client.usericonManager.setCustomData(data);
     }
     
-    public java.util.List<Notification> getNotificationData() {
+    public List<Notification> getNotificationData() {
         return notificationManager.getData();
     }
     
-    public void setNotificationData(java.util.List<Notification> data) {
+    public void setNotificationData(List<Notification> data) {
         notificationManager.setData(data);
     }
     


### PR DESCRIPTION
This small PR removes `java.util.List` paths in several places of the MainGui class.
These paths are completely useless, because the `java.util.List` is already imported a long time ago.

https://github.com/chatty/chatty/blob/56d1ba7dbe700f66d0039eaea42daacac4f96faa/src/chatty/gui/MainGui.java#L20-L24