### PR TITLE
 Add configurable userdialog message limit

### DIFF
--- a/src/chatty/SettingsManager.java
+++ b/src/chatty/SettingsManager.java
@@ -288,6 +288,7 @@ public class SettingsManager {
         settings.addBoolean("openUserDialogByMouse", true);
         settings.addBoolean("reuseUserDialog", false);
         settings.addLong("clearUserMessages", 12);
+        settings.addLong("UserDialogMessageLimit", 100);
 
         // History / Favorites
         settings.addMap("channelHistory",new TreeMap(), Setting.LONG);

--- a/src/chatty/User.java
+++ b/src/chatty/User.java
@@ -7,10 +7,14 @@ import chatty.util.api.usericons.UsericonManager;
 import chatty.util.colors.HtmlColors;
 import chatty.gui.NamedColor;
 import chatty.gui.components.textpane.ModLogInfo;
+import chatty.util.settings.Setting;
+import chatty.util.settings.Settings;
+import chatty.util.settings.SettingsListener;
 import chatty.util.Debugging;
 import chatty.util.StringUtil;
 import chatty.util.api.pubsub.ModeratorActionData;
 import java.awt.Color;
+import static java.lang.Math.toIntExact;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -26,6 +30,8 @@ import java.util.regex.Pattern;
  * @author tduva
  */
 public class User implements Comparable {
+    
+    private Settings settings;
     
     private static final Pattern SPLIT_EMOTESET = Pattern.compile("[^0-9]");
     
@@ -49,7 +55,7 @@ public class User implements Comparable {
         new NamedColor("SpringGreen", 0, 255, 127)
     };
     
-    private static final int MAXLINES = 100;
+    private int MAXLINES = 100;
     
     //========
     // Basics
@@ -298,6 +304,10 @@ public class User implements Comparable {
     
     public synchronized int getMaxNumberOfLines() {
         return MAXLINES;
+    }
+    
+    public void setMaxNumberOfLines(int num) {
+        this.MAXLINES = num;
     }
     
     /**

--- a/src/chatty/User.java
+++ b/src/chatty/User.java
@@ -14,7 +14,6 @@ import chatty.util.Debugging;
 import chatty.util.StringUtil;
 import chatty.util.api.pubsub.ModeratorActionData;
 import java.awt.Color;
-import static java.lang.Math.toIntExact;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;

--- a/src/chatty/UserManager.java
+++ b/src/chatty/UserManager.java
@@ -6,7 +6,6 @@ import chatty.util.api.usericons.UsericonManager;
 import chatty.util.BotNameManager;
 import chatty.util.StringUtil;
 import chatty.util.settings.Settings;
-import static java.lang.Math.toIntExact;
 import java.util.Map.Entry;
 import java.util.*;
 import java.util.logging.Logger;
@@ -255,9 +254,9 @@ public class UserManager {
             getUsersByChannel(room.getChannel()).put(name, user);
             
             // Set history length
-            long UserDialogMessageLimit = settings.getLong("UserDialogMessageLimit");
+            int UserDialogMessageLimit = settings.getInt("UserDialogMessageLimit");
             if (UserDialogMessageLimit >= 0) {
-                user.setMaxNumberOfLines(toIntExact(UserDialogMessageLimit));
+                user.setMaxNumberOfLines(UserDialogMessageLimit);
             }
         }
         return user;

--- a/src/chatty/UserManager.java
+++ b/src/chatty/UserManager.java
@@ -6,6 +6,7 @@ import chatty.util.api.usericons.UsericonManager;
 import chatty.util.BotNameManager;
 import chatty.util.StringUtil;
 import chatty.util.settings.Settings;
+import static java.lang.Math.toIntExact;
 import java.util.Map.Entry;
 import java.util.*;
 import java.util.logging.Logger;
@@ -252,6 +253,12 @@ public class UserManager {
             }
             // Put User into the map for the channel
             getUsersByChannel(room.getChannel()).put(name, user);
+            
+            // Set history length
+            long UserDialogMessageLimit = settings.getLong("UserDialogMessageLimit");
+            if (UserDialogMessageLimit >= 0) {
+                user.setMaxNumberOfLines(toIntExact(UserDialogMessageLimit));
+            }
         }
         return user;
     }

--- a/src/chatty/gui/components/settings/ModerationSettings.java
+++ b/src/chatty/gui/components/settings/ModerationSettings.java
@@ -62,6 +62,12 @@ public class ModerationSettings extends SettingsPanel {
                 d.makeGbc(0, 3, 1, 1, GridBagConstraints.EAST));
         userInfo.add(d.addComboLongSetting("clearUserMessages", new int[]{-1, 3, 6, 12, 24}),
                 d.makeGbc(1, 3, 1, 1, GridBagConstraints.WEST));
+        
+        userInfo.add(new JLabel(Language.getString("settings.long.UserDialogMessageLimit.label")),
+                d.makeGbc(0, 4, 1, 1, GridBagConstraints.EAST));
+        userInfo.add(d.addSimpleLongSetting("UserDialogMessageLimit", 3, true),
+                d.makeGbc(1, 4, 1, 1, GridBagConstraints.WEST));
+                
     }
     
 }

--- a/src/chatty/lang/Strings.properties
+++ b/src/chatty/lang/Strings.properties
@@ -746,6 +746,7 @@ settings.long.clearUserMessages.option.6 = 6 Hours
 settings.long.clearUserMessages.option.12 = 12 Hours
 settings.long.clearUserMessages.option.24 = 24 Hours
 settings.long.clearUserMessages.label = Clear message history of users inactive for:
+settings.long.UserDialogMessageLimit.label = Limit per-user message history to:
 
 !-- Names --!
 settings.label.mentions = Clickable Mentions:

--- a/src/chatty/util/settings/Settings.java
+++ b/src/chatty/util/settings/Settings.java
@@ -316,6 +316,10 @@ public class Settings {
     public long getLong(String setting) {
         return ((Number)(get(setting, Setting.LONG))).longValue();
     }
+    
+    public int getInt(String setting) {
+        return ((Number)(get(setting, Setting.LONG))).intValue();
+    }
 
 
     /**


### PR DESCRIPTION
Adds configurable scroll-back to user dialogs. Useful in particularly busy chats when 100 just isn't enough.

![image](https://user-images.githubusercontent.com/49329071/55663989-deb24900-581e-11e9-833a-4023ad586af5.png)

Apologies in advance if this is somehow wrong, new to this whole thing :)