### PR TITLE
move to id.twitch.tv

### DIFF
--- a/src/chatty/TwitchClient.java
+++ b/src/chatty/TwitchClient.java
@@ -96,7 +96,7 @@ public class TwitchClient {
      * added.
      */
     public static final String REQUEST_TOKEN_URL = ""
-            + "https://api.twitch.tv/kraken/oauth2/authorize"
+            + "https://id.twitch.tv/oauth2/authorize"
             + "?response_type=token"
             + "&client_id="+Chatty.CLIENT_ID
             + "&redirect_uri="+Chatty.REDIRECT_URI

--- a/src/chatty/gui/components/help/help-guide2.html
+++ b/src/chatty/gui/components/help/help-guide2.html
@@ -33,7 +33,7 @@
             <th>Follow</th>
         </tr>
         <tr>
-            <td><a href="https://api.twitch.tv/kraken/oauth2/authorize?response_type=token&client_id=spyiu9jqdnfjtwv6l1xjk5zgt8qb91l&redirect_uri=http://127.0.0.1:61324/token/&force_verify=true&scope=chat_login+channel_editor+channel_commercial+user_read+channel_subscriptions+user_follows_edit">Request new login</a></td>
+            <td><a href="https://id.twitch.tv/oauth2/authorize?response_type=token&client_id=spyiu9jqdnfjtwv6l1xjk5zgt8qb91l&redirect_uri=http://127.0.0.1:61324/token/&force_verify=true&scope=chat_login+channel_editor+channel_commercial+user_read+channel_subscriptions+user_follows_edit">Request new login</a></td>
             <td>✓</td>
             <td>✓</td>
             <td>✓</td>
@@ -42,7 +42,7 @@
             <td>✓</td>
         </tr>
         <tr>
-            <td><a href="https://api.twitch.tv/kraken/oauth2/authorize?response_type=token&client_id=spyiu9jqdnfjtwv6l1xjk5zgt8qb91l&redirect_uri=http://127.0.0.1:61324/token/&force_verify=true&scope=chat_login+channel_editor+channel_commercial+user_read+channel_subscriptions">Request new login</a></td>
+            <td><a href="https://id.twitch.tv/oauth2/authorize?response_type=token&client_id=spyiu9jqdnfjtwv6l1xjk5zgt8qb91l&redirect_uri=http://127.0.0.1:61324/token/&force_verify=true&scope=chat_login+channel_editor+channel_commercial+user_read+channel_subscriptions">Request new login</a></td>
             <td>✓</td>
             <td>✓</td>
             <td>✓</td>
@@ -51,7 +51,7 @@
             <td></td>
         </tr>
         <tr>
-            <td><a href="https://api.twitch.tv/kraken/oauth2/authorize?response_type=token&client_id=spyiu9jqdnfjtwv6l1xjk5zgt8qb91l&redirect_uri=http://127.0.0.1:61324/token/&force_verify=true&scope=chat_login+user_read">Request new login</a></td>
+            <td><a href="https://id.twitch.tv/oauth2/authorize?response_type=token&client_id=spyiu9jqdnfjtwv6l1xjk5zgt8qb91l&redirect_uri=http://127.0.0.1:61324/token/&force_verify=true&scope=chat_login+user_read">Request new login</a></td>
             <td>✓</td>
             <td>✓</td>
             <td></td>
@@ -60,7 +60,7 @@
             <td></td>
         </tr>
         <tr>
-            <td><a href="https://api.twitch.tv/kraken/oauth2/authorize?response_type=token&client_id=spyiu9jqdnfjtwv6l1xjk5zgt8qb91l&redirect_uri=http://127.0.0.1:61324/token/&force_verify=true&scope=chat_login">Request new login</a></td>
+            <td><a href="https://id.twitch.tv/oauth2/authorize?response_type=token&client_id=spyiu9jqdnfjtwv6l1xjk5zgt8qb91l&redirect_uri=http://127.0.0.1:61324/token/&force_verify=true&scope=chat_login">Request new login</a></td>
             <td>✓</td>
             <td></td>
             <td></td>


### PR DESCRIPTION
`api.twitch.tv/kraken/oauth2` was [deprecated](https://discuss.dev.twitch.tv/t/oauth-kraken-migration/14606?u=3ventic) a long time ago. It redirects to the new URLs (for the time being), but there can be some weird behavior, and this also futureproofs it.