### PR TITLE
UpdateDialog: show links to help-releases.html

### DIFF
--- a/src/chatty/gui/MainGui.java
+++ b/src/chatty/gui/MainGui.java
@@ -1509,32 +1509,44 @@ public class MainGui extends JFrame implements Runnable {
     private class MyLinkLabelListener implements LinkLabelListener {
         @Override
         public void linkClicked(String type, String ref) {
-            if (type.equals("help")) {
-                openHelp(ref);
-            } else if (type.equals("help-settings")) {
-                openHelp("help-settings.html", ref);
-            } else if (type.equals("help-commands")) {
-                openHelp("help-custom_commands.html", ref);
-            } else if (type.equals("help-admin")) {
-                openHelp("help-admin.html", ref);
-            } else if (type.equals("help-livestreamer")) {
-                openHelp("help-livestreamer.html", ref);
-            } else if (type.equals("help-whisper")) {
-                openHelp("help-whisper.html", ref);
-            } else if (type.equals("help-laf")) {
-                openHelp("help-laf.html", ref);
-            } else if (type.equals("help-guide2")) {
-                openHelp("help-guide2.html", ref);
-            } else if (type.equals("url")) {
-                UrlOpener.openUrlPrompt(MainGui.this, ref);
-            } else if (type.equals("update")) {
-                if (ref.equals("show")) {
-                    openUpdateDialog();
-                }
-            } else if (type.equals("announcement")) {
-                if (ref.equals("show")) {
-                    //newsDialog.showDialog();
-                }
+            switch (type) {
+                case "help":
+                    openHelp(ref);
+                    break;
+                case "help-settings":
+                    openHelp("help-settings.html", ref);
+                    break;
+                case "help-commands":
+                    openHelp("help-custom_commands.html", ref);
+                    break;
+                case "help-admin":
+                    openHelp("help-admin.html", ref);
+                    break;
+                case "help-livestreamer":
+                    openHelp("help-livestreamer.html", ref);
+                    break;
+                case "help-whisper":
+                    openHelp("help-whisper.html", ref);
+                    break;
+                case "help-laf":
+                    openHelp("help-laf.html", ref);
+                    break;
+                case "help-guide2":
+                    openHelp("help-guide2.html", ref);
+                    break;
+                case "url":
+                    UrlOpener.openUrlPrompt(MainGui.this, ref);
+                    break;
+                case "update":
+                    if (ref.equals("show")) {
+                        openUpdateDialog();
+                    }
+                    break;
+                case "announcement":
+                    if (ref.equals("show")) {
+                        //newsDialog.showDialog();
+                    }
+                    break;
             }
         }
     }

--- a/src/chatty/gui/MainGui.java
+++ b/src/chatty/gui/MainGui.java
@@ -1534,6 +1534,9 @@ public class MainGui extends JFrame implements Runnable {
                 case "help-guide2":
                     openHelp("help-guide2.html", ref);
                     break;
+                case "help-releases":
+                    openHelp("help-releases.html", ref);
+                    break;
                 case "url":
                     UrlOpener.openUrlPrompt(MainGui.this, ref);
                     break;

--- a/src/chatty/gui/components/settings/CompletionSettings.java
+++ b/src/chatty/gui/components/settings/CompletionSettings.java
@@ -179,7 +179,7 @@ public class CompletionSettings extends SettingsPanel {
             setTitle("Custom Completion Items");
             setDefaultCloseOperation(HIDE_ON_CLOSE);
             
-            add(new JLabel("<html><body style='width:300px;padding:7 7 10 7;'>"
+            add(new JLabel("<html><body style='width:300px;padding:7px 7px 10px 7px;'>"
                     + "Use <kbd>TAB</kbd> to complete '.Key' (prefixed "
                     + "with a dot) to 'Value'.<br />"
                     + "<br />"

--- a/src/chatty/gui/components/updating/UpdateDialog.java
+++ b/src/chatty/gui/components/updating/UpdateDialog.java
@@ -271,7 +271,8 @@ public class UpdateDialog extends JDialog {
                     + "<small>(Downloads, closes Chatty and runs the setup: "+asset.getName()+")</small></div>");
         }
         downloadsInfo.setVisible(true);
-        downloadsInfo.setText("<html><body style='padding:0 10 0 10;'><p>Direct downloads (manual install):</p>"+makeDownloadLinks(latest));
+        downloadsInfo.setText("<html><body style='padding:0px 10px 0px 10px;'><p>Direct downloads (manual install):</p>"
+                + makeDownloadLinks(latest));
     }
     
     private String makeDownloadLinks(Release release) {

--- a/src/chatty/gui/components/updating/UpdateDialog.java
+++ b/src/chatty/gui/components/updating/UpdateDialog.java
@@ -122,6 +122,10 @@ public class UpdateDialog extends JDialog {
         gbc = GuiUtil.makeGbc(0, 4, 1, 1, GridBagConstraints.WEST);
         add(enableCheckBeta, gbc);
         
+        LinkLabel releaseNotes = new LinkLabel("[help-releases:top Release notes]", linkLabelListener);
+        gbc = GuiUtil.makeGbc(0, 5, 1, 1, GridBagConstraints.WEST);
+        add(releaseNotes, gbc);
+        
         //gbc = GuiUtil.makeGbc(0, 5, 1, 1);
         //gbc.fill = GridBagConstraints.HORIZONTAL;
         //gbc.weightx = 1;
@@ -213,7 +217,7 @@ public class UpdateDialog extends JDialog {
         setTitle("You are up-to-date!");
         
         String main = HTML_PREFIX + ("<div style='font-size:1.2em;padding-left:10px;padding-right:10px;'>"
-                + "You&nbsp;are&nbsp;running&nbsp;the&nbsp;latest&nbsp;version"
+                + "You&nbsp;are&nbsp;running&nbsp;the&nbsp;[help-releases:top latest&nbsp;version]"
                 + "</div>");
         if (newerBeta) {
             main += "<div style='margin:5px'>There is a newer beta version though!</div>";

--- a/src/chatty/gui/components/updating/UpdateDialog.java
+++ b/src/chatty/gui/components/updating/UpdateDialog.java
@@ -330,7 +330,7 @@ public class UpdateDialog extends JDialog {
         settings.addLong("versionLastChecked", 0L);
         
         LinkLabelListener linkLabelListener = (type, ref) -> {
-            System.out.println("Link clicked: "+ref);
+            System.out.println("Link clicked: " + type + ":" + ref);
         };
         
         Releases data = testReleases();

--- a/src/chatty/gui/components/updating/UpdateDialog.java
+++ b/src/chatty/gui/components/updating/UpdateDialog.java
@@ -212,7 +212,9 @@ public class UpdateDialog extends JDialog {
     private void setVersion(Release release, boolean newerBeta) {
         setTitle("You are up-to-date!");
         
-        String main = HTML_PREFIX+"<div style='font-size:1.2em;padding-left:10px;padding-right:10px;'>You are running the latest version</div>".replaceAll(" ", "&nbsp;");
+        String main = HTML_PREFIX + ("<div style='font-size:1.2em;padding-left:10px;padding-right:10px;'>"
+                + "You&nbsp;are&nbsp;running&nbsp;the&nbsp;latest&nbsp;version"
+                + "</div>");
         if (newerBeta) {
             main += "<div style='margin:5px'>There is a newer beta version though!</div>";
         }

--- a/src/chatty/gui/components/updating/UpdateDialog.java
+++ b/src/chatty/gui/components/updating/UpdateDialog.java
@@ -122,10 +122,10 @@ public class UpdateDialog extends JDialog {
         gbc = GuiUtil.makeGbc(0, 4, 1, 1, GridBagConstraints.WEST);
         add(enableCheckBeta, gbc);
         
-        gbc = GuiUtil.makeGbc(0, 5, 1, 1);
-        gbc.fill = GridBagConstraints.HORIZONTAL;
-        gbc.weightx = 1;
-        gbc.insets = new Insets(1, 12, 5, 5);
+        //gbc = GuiUtil.makeGbc(0, 5, 1, 1);
+        //gbc.fill = GridBagConstraints.HORIZONTAL;
+        //gbc.weightx = 1;
+        //gbc.insets = new Insets(1, 12, 5, 5);
         //add(new JLabel(BETA_INFO), gbc);
         
         closeButton = new JButton(Language.getString("dialog.button.close"));


### PR DESCRIPTION
Main change is in the last commit. The rest are the minor bugfixes and code cleanup.

From message of the last commit:

> User who clicks on the "Check for update" menu item might be interested
> in full release notes, so add a couple of links to the file help-releases.html:
> 
>   1. at the bottom of UpdateDialog, always shown;
>   2. as words "latest version" in the text "You are running the latest
>      version" in the UpdateDialog, shown only when the latest version
>      is being used.

I'm not sure about the placement of the links to `help-releases.html`. These two are the best that I could come up with:

![chatty_20210421_release_notes_links](https://user-images.githubusercontent.com/624072/115625408-536c5900-a2fc-11eb-942a-f2c9fa0473e4.png)

Left: `UpdateDialog#main`, right: `UpdateDialog` from full Chatty (menu Help > Check for update).