### PR TITLE
github action for `./gradlew build` on PRs

### DIFF
--- a/.github/workflows/gradle-build-pr.yml
+++ b/.github/workflows/gradle-build-pr.yml
@@ -1,0 +1,16 @@
+name: Run Gradle on PRs
+on: pull_request
+jobs:
+  gradle:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - uses: eskatos/gradle-command-action@v1
+      with:
+        arguments: build


### PR DESCRIPTION
Set up GitHub Action for running command `./gradlew build` for pull
requests.  The Yaml file is almost verbatim (aside from Java version)
copied from https://github.com/marketplace/actions/gradle-command

----

Example run: https://github.com/rybak/chatty/actions/runs/814372327