### PR TITLE
Adding URI protocol identifier for Streamlink/Livestreamer commandline generation

### DIFF
--- a/src/chatty/gui/components/LivestreamerDialog.java
+++ b/src/chatty/gui/components/LivestreamerDialog.java
@@ -215,7 +215,7 @@ public class LivestreamerDialog extends JDialog {
      */
     public void open(String stream, String quality) {
         if (stream != null) {
-            String url = "twitch.tv/" + stream;
+            String url = "https://twitch.tv/" + stream;
             if (!Helper.isValidChannel(stream)) {
                 url = stream;
             }


### PR DESCRIPTION
Adding scheme (https) to commandline URI for consistency and at the same time opening up the ability to utilize media players that already have twitch-playback capable plugins built in (like youtube-dl with mpchc or mpv) that will not accept URI input without protocol identifier . (Streamlink allows incomplete URI for user convenience)

![image](https://user-images.githubusercontent.com/7331379/119279602-064a1280-bc2d-11eb-8942-9bb7c260ecb7.png)
