### PR TITLE
Fix UserInfo close button focus

### DIFF
--- a/src/chatty/gui/components/userinfo/UserInfo.java
+++ b/src/chatty/gui/components/userinfo/UserInfo.java
@@ -451,8 +451,8 @@ public class UserInfo extends JDialog {
         banReasons.reset();
         singleMessage.setSelected(false);
         setUser(user, msgId, autoModMsgId, localUsername);
-        closeButton.requestFocusInWindow();
         setVisible(true);
+        closeButton.requestFocusInWindow();
     }
     
     /**


### PR DESCRIPTION
Since c9d2f46433535405ebf638c5d8dda709d51d11ae, the second and the following UserInfo window that get opened have focus on the first action button instead of the close button. From the code it seems like this was not wanted, setting focus after showing the window focuses the right button on opening.