### PR TITLE
Support matching several channels in notifications

### DIFF
--- a/src/chatty/gui/components/help/help-settings.html
+++ b/src/chatty/gui/components/help/help-settings.html
@@ -1652,8 +1652,9 @@
     
     <h3>Event settings (Notification/Sound)</h3>
     <dl class="dl-settings">
-        <dt>Channel</dt>
-        <dd>Name of the channel this item should be restricted to.</dd>
+        <dt>Channels</dt>
+        <dd>Name of the channel or channels (comma-separated) this item should be
+            restricted to.</dd>
         
         <dt>Match</dt>
         <dd>Match the given text or message, in the same format as for

--- a/src/chatty/gui/components/settings/NotificationEditor.java
+++ b/src/chatty/gui/components/settings/NotificationEditor.java
@@ -17,7 +17,6 @@ import chatty.util.StringUtil;
 import chatty.util.settings.Settings;
 import java.awt.Color;
 import java.awt.Component;
-import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.GridBagConstraints;
 import static java.awt.GridBagConstraints.EAST;
@@ -30,7 +29,6 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -158,7 +156,7 @@ class NotificationEditor extends TableEditor<Notification> {
             // Text
             String text;
             if (column == 0) {
-                String channel = n.hasChannel() ? " ("+n.channel+")" : "";
+                String channel = n.hasChannels() ? " (" + n.serializeChannels() + ")" : "";
                 String matcher = n.hasMatcher() ? "&nbsp;"+n.getMatcherString() : "";
                 text = String.format("%s%s\n%s",
                         n.type.label,
@@ -225,7 +223,7 @@ class NotificationEditor extends TableEditor<Notification> {
         private final GenericComboSetting<Notification.Type> type;
         private final GenericComboSetting<Notification.State> desktopState;
         private final GenericComboSetting<Notification.State> soundState;
-        private final SimpleStringSetting channel;
+        private final SimpleStringSetting channels;
         private final EditorStringSetting matcher;
         private final ColorTemplates colorTemplates;
         private final ColorSetting foregroundColor;
@@ -297,12 +295,12 @@ class NotificationEditor extends TableEditor<Notification> {
             options.setLayout(new BoxLayout(options, BoxLayout.PAGE_AXIS));
             optionsAssoc = new HashMap<>();
             
-            channel = new SimpleStringSetting(20, true);
+            channels = new SimpleStringSetting(20, true, DataFormatter.TRIM);
             HighlighterTester matcherEditor = new HighlighterTester(dialog, false, "notification");
             matcherEditor.setAllowEmpty(true);
             matcher = new EditorStringSetting(dialog, "Match Notification Text", 20, matcherEditor);
             
-            SettingsUtil.addLabeledComponent(optionsPanel, "settings.notifications.channel", 0, 2, 1, EAST, channel);
+            SettingsUtil.addLabeledComponent(optionsPanel, "settings.notifications.channel", 0, 2, 1, EAST, channels);
             SettingsUtil.addLabeledComponent(optionsPanel, "settings.notifications.textMatch", 0, 3, 1, EAST, matcher);
             
             optionsPanel.add(options, GuiUtil.makeGbc(0, 4, 2, 1, GridBagConstraints.WEST));
@@ -557,7 +555,7 @@ class NotificationEditor extends TableEditor<Notification> {
                 current = preset;
                 
                 type.setSettingValue(preset.type);
-                channel.setSettingValue(preset.channel);
+                channels.setSettingValue(preset.serializeChannels());
                 matcher.setSettingValue(preset.matcher);
                 desktopState.setSettingValue(preset.desktopState);
                 foregroundColor.setSettingValue(HtmlColors.getColorString(preset.foregroundColor));
@@ -574,7 +572,7 @@ class NotificationEditor extends TableEditor<Notification> {
                 current = null;
                 
                 type.setSelectedIndex(0);
-                channel.setSettingValue(null);
+                channels.setSettingValue("");
                 matcher.setSettingValue(null);
                 desktopState.setSettingValue(Notification.State.ALWAYS);
                 foregroundColor.setSettingValue("black");
@@ -628,7 +626,7 @@ class NotificationEditor extends TableEditor<Notification> {
             b.setVolume(volumeSlider.getSettingValue());
             b.setSoundCooldown(soundCooldown.getSettingValue(0L).intValue());
             b.setSoundInactiveCooldown(soundInactiveCooldown.getSettingValue(0L).intValue());
-            b.setChannel(channel.getSettingValue());
+            b.setChannels(channels.getSettingValue());
             b.setMatcher(matcher.getSettingValue());
             b.setOptions(getSubTypes());
             

--- a/src/chatty/gui/notifications/Notification.java
+++ b/src/chatty/gui/notifications/Notification.java
@@ -14,6 +14,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.logging.Logger;
 
 /**
@@ -135,7 +137,7 @@ public class Notification {
         private int soundCooldown;
         private int soundInactiveCooldown;
         private List<String> options = new ArrayList<>();
-        private String channel;
+        private String channels;
         
         public Builder(Type type) {
             this.type = type;
@@ -191,8 +193,8 @@ public class Notification {
             return this;
         }
         
-        public Builder setChannel(String channel) {
-            this.channel = channel;
+        public Builder setChannels(String channels) {
+            this.channels = channels;
             return this;
         }
         
@@ -205,7 +207,7 @@ public class Notification {
     
     public final Type type;
     public final List<String> options;
-    public final String channel;
+    private final Set<String> channels;
     public final String matcher;
     private final Highlighter.HighlightItem matcherItem;
     
@@ -231,8 +233,7 @@ public class Notification {
         // Both
         type = builder.type;
         this.options = builder.options;
-        String tempChannel = StringUtil.trim(builder.channel);
-        this.channel = tempChannel == null || tempChannel.isEmpty() ? null : Helper.toChannel(tempChannel);
+        channels = parseChannels(builder.channels);
         this.matcher = StringUtil.trim(builder.matcher);
         if (matcher != null && !matcher.isEmpty()) {
             this.matcherItem = new Highlighter.HighlightItem(matcher, "notification");
@@ -252,6 +253,20 @@ public class Notification {
         this.soundVolume = builder.soundVolume;
         this.soundCooldown = builder.soundCooldown;
         this.soundInactiveCooldown = builder.soundInactiveCooldown;
+    }
+
+    private static Set<String> parseChannels(String channels) {
+        if (channels == null) {
+            return null;
+        }
+        Set<String> parsedChannels = Helper.parseChannelsFromString(channels, true);
+        if (!parsedChannels.isEmpty()) {
+            Set<String> result = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+            result.addAll(parsedChannels);
+            return result;
+        } else {
+            return null;
+        }
     }
 
     public String getDesktopState() {
@@ -286,10 +301,10 @@ public class Notification {
         if (channel == null) {
             return true;
         }
-        if (this.channel == null) {
+        if (channels == null) {
             return true;
         }
-        return channel.equalsIgnoreCase(this.channel);
+        return channels.contains(Helper.toChannel(channel));
     }
     
     public boolean matches(String text, String channel, Addressbook ab, User user, User localUser, MsgTags tags) {
@@ -299,8 +314,12 @@ public class Notification {
         return matcherItem.matches(Highlighter.HighlightItem.Type.ANY, text, null, channel, ab, user, localUser, tags);
     }
     
-    public boolean hasChannel() {
-        return channel != null;
+    public boolean hasChannels() {
+        return channels != null && !channels.isEmpty();
+    }
+
+    public String serializeChannels() {
+        return channels == null ? "" : Helper.buildStreamsString(channels);
     }
 
     public boolean hasOption(TypeOption option) {
@@ -332,7 +351,7 @@ public class Notification {
         result.add(soundVolume);
         result.add(soundCooldown);
         result.add(soundInactiveCooldown);
-        result.add(channel);
+        result.add(serializeChannels());
         result.add(matcher);
         return result;
     }
@@ -350,7 +369,7 @@ public class Notification {
             long volume = ((Number)list.get(8)).longValue();
             int soundCooldown = ((Number)list.get(9)).intValue();
             int soundInactiveCooldown = ((Number)list.get(10)).intValue();
-            String channel = (String)list.get(11);
+            String channels = (String)list.get(11);
             String matcher = (String)list.get(12);
             
             Builder b = new Builder(type);
@@ -364,7 +383,7 @@ public class Notification {
             b.setVolume(volume);
             b.setSoundCooldown(soundCooldown);
             b.setSoundInactiveCooldown(soundInactiveCooldown);
-            b.setChannel(channel);
+            b.setChannels(channels);
             b.setMatcher(matcher);
             return new Notification(b);
         } catch (Exception ex) {

--- a/src/chatty/gui/notifications/Notification.java
+++ b/src/chatty/gui/notifications/Notification.java
@@ -221,8 +221,7 @@ public class Notification {
     public final long soundVolume;
     public final int soundCooldown;
     public final int soundInactiveCooldown;
-    public int soundFileDelay;
-    
+
     // State
     private long lastMatched;
     private long lastSoundPlayed;

--- a/src/chatty/lang/Strings.properties
+++ b/src/chatty/lang/Strings.properties
@@ -1194,6 +1194,7 @@ settings.boolean.nHideOnStart = Prevent notifications on start
 settings.boolean.nHideOnStart.tip = Within the first 120 seconds after starting Chatty, no notifications will be triggered
 settings.notifications.event = Event:
 settings.notifications.channel = Channel:
+settings.notifications.channel.tip = One or several Twitch channels (comma-separated), where this notification will be triggered
 settings.notifications.textMatch = Match:
 settings.notifications.textMatch.tip = Trigger only when notification text (or other properties) matches this setting, using Highlight matching format
 settings.notifications.soundFile = Sound file:

--- a/test/chatty/HelperTest.java
+++ b/test/chatty/HelperTest.java
@@ -4,6 +4,8 @@ package chatty;
 import chatty.util.StringUtil;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.regex.Matcher;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -266,4 +268,31 @@ public class HelperTest {
         assertEquals(new HashSet<>(Arrays.asList(result)), Helper.parseChannelsFromString(input, prepend));
     }
     
+    @Test
+    public void testChannelsListParsingRoundTrip() {
+        Set<String> expected = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        expected.add("foo");
+        expected.add("bar");
+        expected.add("hello");
+        expected.add("world");
+        TreeSet<String> actual = channelListRoundTrip(expected, false);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testPrependedChannelsListParsingRoundTrip() {
+        Set<String> expected = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        expected.add("#foo");
+        expected.add("#bar");
+        expected.add("#hello");
+        expected.add("#world");
+        TreeSet<String> actual = channelListRoundTrip(expected, true);
+        assertEquals(expected, actual);
+    }
+
+    private TreeSet<String> channelListRoundTrip(Set<String> original, boolean prepend) {
+        TreeSet<String> copy = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        copy.addAll(Helper.parseChannelsFromString(Helper.buildStreamsString(original), prepend));
+        return copy;
+    }
 }

--- a/test/chatty/gui/notifications/NotificationTest.java
+++ b/test/chatty/gui/notifications/NotificationTest.java
@@ -21,15 +21,41 @@ public class NotificationTest {
         assertTrue(notification.matchesChannel(null));
         assertTrue(notification.matchesChannel("#foobar"));
         assertTrue(notification.matchesChannel("#fooBAR"));
+        assertTrue(notification.matchesChannel("foobar"));
+        assertTrue(notification.matchesChannel("Foobar"));
         notification = createStreamStatusNotification("#fOOBAR");
         assertTrue(notification.matchesChannel(null));
         assertTrue(notification.matchesChannel("#foobar"));
         assertTrue(notification.matchesChannel("#FOObar"));
+        assertTrue(notification.matchesChannel("foobar"));
+        assertTrue(notification.matchesChannel("fooBar"));
     }
 
-    private Notification createStreamStatusNotification(String channel) {
+    @Test
+    public void testThatMultipleChannelMatchingWorks() {
+        Notification notification = createStreamStatusNotification(" FOO, bar ,baZ ");
+        assertTrue(notification.matchesChannel("foo"));
+        assertTrue(notification.matchesChannel("bar"));
+        assertTrue(notification.matchesChannel("baz"));
+        assertTrue(notification.matchesChannel("#foo"));
+        assertTrue(notification.matchesChannel("#bar"));
+        assertTrue(notification.matchesChannel("#baz"));
+        assertTrue(notification.matchesChannel("#FOO"));
+        assertTrue(notification.matchesChannel("#baR"));
+        notification = createStreamStatusNotification("#fOO ,#BAR, #BAZ");
+        assertTrue(notification.matchesChannel("foo"));
+        assertTrue(notification.matchesChannel("bar"));
+        assertTrue(notification.matchesChannel("baz"));
+        assertTrue(notification.matchesChannel("#foo"));
+        assertTrue(notification.matchesChannel("#bar"));
+        assertTrue(notification.matchesChannel("#baz"));
+        assertTrue(notification.matchesChannel("#FOO"));
+        assertTrue(notification.matchesChannel("#baR"));
+    }
+
+    private Notification createStreamStatusNotification(String channels) {
         Notification.Builder builder = new Notification.Builder(Notification.Type.STREAM_STATUS)
-                .setChannel(channel);
+                .setChannels(channels);
         return new Notification(builder);
     }
 }

--- a/test/chatty/gui/notifications/NotificationTest.java
+++ b/test/chatty/gui/notifications/NotificationTest.java
@@ -2,6 +2,7 @@ package chatty.gui.notifications;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class NotificationTest {
@@ -13,6 +14,8 @@ public class NotificationTest {
         assertTrue(notification.matchesChannel("#fooBAR"));
         assertTrue(notification.matchesChannel("foobar"));
         assertTrue(notification.matchesChannel("FOObar"));
+        assertTrue(notification.matchesChannel("AnythingGoes"));
+        assertTrue(notification.matchesChannel("#AnythingGoes"));
     }
 
     @Test
@@ -23,12 +26,16 @@ public class NotificationTest {
         assertTrue(notification.matchesChannel("#fooBAR"));
         assertTrue(notification.matchesChannel("foobar"));
         assertTrue(notification.matchesChannel("Foobar"));
+        assertFalse(notification.matchesChannel("NotInChannelList"));
+        assertFalse(notification.matchesChannel("#NotInChannelList"));
         notification = createStreamStatusNotification("#fOOBAR");
         assertTrue(notification.matchesChannel(null));
         assertTrue(notification.matchesChannel("#foobar"));
         assertTrue(notification.matchesChannel("#FOObar"));
         assertTrue(notification.matchesChannel("foobar"));
         assertTrue(notification.matchesChannel("fooBar"));
+        assertFalse(notification.matchesChannel("NotInChannelList"));
+        assertFalse(notification.matchesChannel("#NotInChannelList"));
     }
 
     @Test
@@ -42,6 +49,8 @@ public class NotificationTest {
         assertTrue(notification.matchesChannel("#baz"));
         assertTrue(notification.matchesChannel("#FOO"));
         assertTrue(notification.matchesChannel("#baR"));
+        assertFalse(notification.matchesChannel("NotInChannelList"));
+        assertFalse(notification.matchesChannel("#NotInChannelList"));
         notification = createStreamStatusNotification("#fOO ,#BAR, #BAZ");
         assertTrue(notification.matchesChannel("foo"));
         assertTrue(notification.matchesChannel("bar"));
@@ -51,6 +60,8 @@ public class NotificationTest {
         assertTrue(notification.matchesChannel("#baz"));
         assertTrue(notification.matchesChannel("#FOO"));
         assertTrue(notification.matchesChannel("#baR"));
+        assertFalse(notification.matchesChannel("NotInChannelList"));
+        assertFalse(notification.matchesChannel("#NotInChannelList"));
     }
 
     private Notification createStreamStatusNotification(String channels) {

--- a/test/chatty/gui/notifications/NotificationTest.java
+++ b/test/chatty/gui/notifications/NotificationTest.java
@@ -1,0 +1,35 @@
+package chatty.gui.notifications;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class NotificationTest {
+    @Test
+    public void testThatMatchingAgainstNullChannelsWorks() {
+        Notification notification = createStreamStatusNotification(null);
+        assertTrue(notification.matchesChannel(null));
+        assertTrue(notification.matchesChannel("#foobar"));
+        assertTrue(notification.matchesChannel("#fooBAR"));
+        assertTrue(notification.matchesChannel("foobar"));
+        assertTrue(notification.matchesChannel("FOObar"));
+    }
+
+    @Test
+    public void testThatSingleChannelMatchingWorks() {
+        Notification notification = createStreamStatusNotification("FOObar");
+        assertTrue(notification.matchesChannel(null));
+        assertTrue(notification.matchesChannel("#foobar"));
+        assertTrue(notification.matchesChannel("#fooBAR"));
+        notification = createStreamStatusNotification("#fOOBAR");
+        assertTrue(notification.matchesChannel(null));
+        assertTrue(notification.matchesChannel("#foobar"));
+        assertTrue(notification.matchesChannel("#FOObar"));
+    }
+
+    private Notification createStreamStatusNotification(String channel) {
+        Notification.Builder builder = new Notification.Builder(Notification.Type.STREAM_STATUS)
+                .setChannel(channel);
+        return new Notification(builder);
+    }
+}


### PR DESCRIPTION
This has been a personal itch of mine ever since I've started using notifications in Chatty. In addition to unit tests, I've been running this code in my own Chatty install for two months with no issues.

Even though can do that through the Match field already, it might be easier this way for people who are using simpler notifications, without complex Match rules. This will also make notifications more consistent with other parts of UI, which have a list of channels, like the "Channel:" field in the "Connect" dialog.

The actual functional change is in the fourth commit. First three commits are code cleanup and adding of tests to make sure that the functional change doesn't break existing functionality (this can be checked with `git rebase -i master -x './gradlew test'`). Special care has been taken to make sure that old notification settings can still be used with new code—see details in the fourth commit.

### Example

Setting:

![notification-several-channels-example-1](https://user-images.githubusercontent.com/624072/123557884-b9111180-d793-11eb-8265-31bfc12332cd.png)

Notification on startup:
![notification-several-channels-example-3](https://user-images.githubusercontent.com/624072/123557885-badad500-d793-11eb-9e6d-323787e6a767.png)
