### PR TITLE
Replaced usage of deprecated Long class constructor to fix warnings.

### DIFF
--- a/src/chatty/gui/components/settings/SliderLongSetting.java
+++ b/src/chatty/gui/components/settings/SliderLongSetting.java
@@ -63,7 +63,7 @@ public class SliderLongSetting extends JPanel implements LongSetting {
     }
     
     private void updateLabel() {
-        valueLabel.setText(LABEL_PREFIX+new Long(value).toString());
+        valueLabel.setText(LABEL_PREFIX+Long.valueOf(value).toString());
     }
     
     public void setMajorTickSpacing(int value) {

--- a/src/chatty/util/SimpleCache.java
+++ b/src/chatty/util/SimpleCache.java
@@ -50,7 +50,7 @@ public class SimpleCache {
     public void save(String data) {
         LOGGER.info(debugPrefix+" Cache: Trying to save..");
         try (BufferedWriter writer = Files.newBufferedWriter(file,CHARSET)) {
-            writer.write(new Long(System.currentTimeMillis() / 1000).toString()+"\n");
+            writer.write(Long.valueOf(System.currentTimeMillis() / 1000).toString()+"\n");
             writer.write(data);
             LOGGER.info(debugPrefix+" Cache: Saved");
         }


### PR DESCRIPTION
Hi, I had tried build with OpenJDK 17 — seems to be good but I got two warnings about the deprecated constructor. So this small PR fixes them.
https://docs.oracle.com/javase/9/docs/api/java/lang/Long.html#Long-long- 

<details><summary><b>Logs</b>:</summary>

```
chatty\src\chatty\gui\components\settings\SliderLongSetting.java:66: warning: [removal] Long(long) in Long has been deprecated and marked for removal
        valueLabel.setText(LABEL_PREFIX+new Long(value).toString());
                                        ^
chatty\src\chatty\util\SimpleCache.java:53: warning: [removal] Long(long) in Long has been deprecated and marked for removal
            writer.write(new Long(System.currentTimeMillis() / 1000).toString()+"\n");
                         ^
```

</details>