### PR TITLE
Make settings directory follow xdg specification

### DIFF
--- a/src/chatty/Chatty.java
+++ b/src/chatty/Chatty.java
@@ -129,6 +129,12 @@ public class Chatty {
             }
         }
         
+        // Check if the legacy settings directory exists and move it to follow XDG specifications
+        File legacySettingsDir = new File(System.getProperty("user.home") + File.separator + ".chatty");
+        if (legacySettingsDir.exists()) {
+            legacySettingsDir.renameTo(new File(getUserDataDirectory()));
+        }
+
         if (parsedArgs.containsKey("appwdir") && !parsedArgs.containsKey("regularwdir")) {
             Path path = Stuff.determineJarPath();
             if (path != null) {
@@ -162,7 +168,7 @@ public class Chatty {
                 invalidSettingsDir = path.toString();
             }
         }
-        
+
         final TwitchClient client = new TwitchClient(parsedArgs);
         
         // Adding listener just in case, will do nothing if not used
@@ -235,10 +241,21 @@ public class Chatty {
         if (settingsDir != null) {
             return settingsDir + File.separator;
         }
-        String dir = System.getProperty("user.home")
-                + File.separator 
-                + ".chatty" 
-                + File.separator;
+        String dir;
+        if (System.getenv("XDG_CONFIG_DIR") != null) {
+            dir = System.getenv("XDG_CONFIG_DIR")
+                  + File.separator
+                  + "chatty"
+                  + File.separator;
+        }
+        else {
+            dir = System.getProperty("user.home")
+                  + File.separator
+                  + ".config"
+                  + File.separator
+                  + "chatty"
+                  + File.separator;
+        }
         new File(dir).mkdirs();
         return dir;
     }


### PR DESCRIPTION
Would close #273

This commit changes `getUserDataDirectory` to return `$XDG_CONFIG_HOME/chatty/`, or `(user.home)/.config/chatty/` if `$XDG_CONFIG_HOME` doesn't exist.
In addition, this commit will cause Chatty to, on startup, detect if the legacy settings directory exists (`(user.home)/.chatty`) and, if it does, move it to whatever `getUserDataDirectory` returns. It does this on startup such that the new settings directory can be taken into effect without needing to restart the client.

This commit should be treated as a first-draft implementation of the idea. It works for a basic end-user case, but may suffer from [Hyrum's Law](https://www.hyrumslaw.com/) if anyone is using scripts to read their settings directory. Should there be a deprecation notification? Perhaps just stick it in the auto-opening release notes in big bold text? Should there be support for both the legacy and XDG directory, and let current users move it if they wish, while having new users use the XDG path? There's many factors to consider when migrating to XDG standards after having a legacy directory for so long.

This was tested on a Linux environment with both XDG_CONFIG_HOME set and unset. Windows environments would also get the `(user.home)/.chatty` directory moved to `(user.home)/.config/chatty`.