### PR TITLE
fix NPE

### DIFF
--- a/src/chatty/gui/MainGui.java
+++ b/src/chatty/gui/MainGui.java
@@ -3479,7 +3479,7 @@ public class MainGui extends JFrame implements Runnable {
                         ignoreMatches = ignoreList.getLastTextMatches();
                         ignoreSource = ignoreList.getLastMatchItems();
                     }
-                    if (!ignoreList.getLastMatchItem().hide()) {
+                    if (ignoreList.getLastMatchItem() != null && !ignoreList.getLastMatchItem().hide()) {
                         ignoredMessages.addMessage(channel, user, text, action,
                                 tagEmotes, bitsForEmotes, whisper, ignoreMatches,
                                 ignoreSource, tags);


### PR DESCRIPTION
fix NPE when you have added user to Ignored without anything else
```
Error Report // 2023-05-10 15:50:40 +0300 / Chatty Version 0.24 Hotkey / Java: 17.0.5 (Red Hat, Inc. / /usr/lib/jvm/java-17-openjdk-17.0.5.0.8-2.fc35.x86_64) OS: Linux (6.0.12-100.fc35.x86_64/amd64) Locale: en_US / [Memory] max: 135,168 / 4,012,032 free: 69,182 (1% full) [Uptime] 13m 28s / Chans: 1

[15:45:24/656] GOT (200/799, 626): https://api.twitch.tv/helix/streams?first=100&user_login=tabula_russia [chatty.util.api.queue.Request/regular]
[15:47:24/128] GET: https://api.twitch.tv/helix/streams/followed?user_id=175064269&first=100 [chatty.util.api.queue.Request/regular]
[15:47:24/137] GET: https://api.twitch.tv/helix/streams?first=100&user_login=tabula_russia [chatty.util.api.queue.Request/regular]
[15:47:24/654] GOT (200/799, 491): https://api.twitch.tv/helix/streams?first=100&user_login=tabula_russia [chatty.util.api.queue.Request/regular]
[15:47:24/667] GOT (200/798, 1438, gzip): https://api.twitch.tv/helix/streams/followed?user_id=175064269&first=100 [chatty.util.api.queue.Request/regular]
[15:47:24/668] Got 3 (limit: 100) followed streams. [chatty.util.api.StreamInfoManager/requestResultFollows]
[15:49:24/132] GET: https://api.twitch.tv/helix/streams?first=100&user_login=tabula_russia [chatty.util.api.queue.Request/regular]
[15:49:24/682] GOT (200/799, 626): https://api.twitch.tv/helix/streams?first=100&user_login=tabula_russia [chatty.util.api.queue.Request/regular]
[15:50:40/774] [class java.lang.NullPointerException/Cannot invoke "chatty.gui.Highlighter$HighlightItem.hide()" because the return value of "chatty.gui.Highlighter.getLastMatchItem()" is null][null][Thread[AWT-EventQueue-0,6,main]]
java.lang.NullPointerException: Cannot invoke "chatty.gui.Highlighter$HighlightItem.hide()" because the return value of "chatty.gui.Highlighter.getLastMatchItem()" is null
	at chatty.gui.MainGui$64.run(MainGui.java:3482)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:771)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:722)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:716)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:741)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
 [chatty.ErrorHandler/uncaughtException]
```