### PR TITLE
View Clip Link

### DIFF
--- a/src/chatty/TwitchClient.java
+++ b/src/chatty/TwitchClient.java
@@ -1617,7 +1617,7 @@ public class TwitchClient {
         });
         commands.add("createClip", p -> {
             api.createClip(p.getRoom().getStream(), result -> {
-                g.printLine(p.getRoom(), result);
+                g.printInfoMultline(p.getRoom(), result);
             });
         });
         c.addNewCommands(commands, this);

--- a/src/chatty/gui/MainGui.java
+++ b/src/chatty/gui/MainGui.java
@@ -3939,6 +3939,15 @@ public class MainGui extends JFrame implements Runnable {
         });
     }
 
+    public void printInfoMultline(final Room room, final String text) {
+        GuiUtil.edt(() -> {
+            String[] lines = text.split("\n");
+            for (String line : lines) {
+                printLine(room, line);
+            }
+        });
+    }
+
     public Object printLine(final Room room, final String line) {
         return printInfo(room, line, null);
     }

--- a/src/chatty/util/api/Requests.java
+++ b/src/chatty/util/api/Requests.java
@@ -475,7 +475,8 @@ public class Requests {
             if (r.responseCode == 202) {
                 String clipUrl = Parsing.getClipUrl(r.text);
                 if (clipUrl != null) {
-                    listener.accept("Edit clip: "+clipUrl);
+                    listener.accept("Edit clip: " + clipUrl
+                            + "\n View Clip: " + clipUrl.replace("/edit", ""));
                 }
                 else {
                     listener.accept("Error creating clip");


### PR DESCRIPTION
Just made a quick change to add a "view" clip link along with the "edit" link. By default, Twitch publishes up to the last 30 seconds of the 90 seconds window and provides a default title for the clip. Sharing this default URL provides a way to quickly create and share a link to a clip without having to publish it first. 