### PR TITLE
Refactor IRCBadges & bugfix

### DIFF
--- a/src/chatty/util/api/usericons/UsericonManager.java
+++ b/src/chatty/util/api/usericons/UsericonManager.java
@@ -425,7 +425,7 @@ public class UsericonManager {
             if (!badges.hasId(id)) {
                 return false;
             }
-            if (version != null && !badges.get(id).equals(version)) {
+            if (version != null && !badges.getVersion(id).equals(version)) {
                 return false;
             }
         }

--- a/src/chatty/util/irc/IrcBadges.java
+++ b/src/chatty/util/irc/IrcBadges.java
@@ -2,67 +2,33 @@
 package chatty.util.irc;
 
 import chatty.util.MiscUtil;
+
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 /**
  * Parses and stores the badge info received through IRC.
- * 
- * The implementation uses a String array for compact storage, which is a bit
- * convoluted, however one of these is created and stored for any user. In busy
- * channels there can be tens of thousands of users after a few hours, so small
- * memory inefficiencies can really add up.
- * 
- * @author tduva
+ *
+ * @author tduva, Regynate
  */
 public class IrcBadges {
-        
-        private final String[] badges;
-        
-        public IrcBadges(String[] badges) {
-            this.badges = badges;
+    private static class Badge {
+        public final String badge;
+        public final String version;
+
+        public Badge(String badge, String version) {
+            this.badge = badge;
+            this.version = version;
         }
-        
-        public String get(String id) {
-            for (int i = 0; i < badges.length; i += 2) {
-                if (badges[i].equals(id)) {
-                    return badges[i + 1];
-                }
-            }
-            return null;
+
+        @Override
+        public String toString() {
+            return badge + '/' + version;
         }
-        
-        public boolean hasId(String id) {
-            return get(id) != null;
-        }
-        
-        public boolean hasIdVersion(String id, String version) {
-            String actualVersion = get(id);
-            return actualVersion != null && actualVersion.equals(version);
-        }
-        
-        public String getVersion(int i) {
-            return badges[i*2+1];
-        }
-        
-        public String getId(int i) {
-            return badges[i*2];
-        }
-        
-        public int size() {
-            return badges.length / 2;
-        }
-        
-        public boolean isEmpty() {
-            return badges.length == 0;
-        }
-        
-        public void forEach(BiConsumer<String, String> consumer) {
-            for (int i = 0; i < badges.length; i += 2) {
-                consumer.accept(badges[i], badges[i+1]);
-            }
-        }
-        
+
         @Override
         public boolean equals(Object obj) {
             if (this == obj) {
@@ -74,41 +40,103 @@ public class IrcBadges {
             if (getClass() != obj.getClass()) {
                 return false;
             }
-            final IrcBadges other = (IrcBadges) obj;
-            return Arrays.deepEquals(this.badges, other.badges);
+            final Badge other = (Badge) obj;
+            return other.version.equals(version) && other.badge.equals(badge);
         }
 
         @Override
         public int hashCode() {
-            int hash = 3;
-            hash = 89 * hash + Arrays.deepHashCode(this.badges);
-            return hash;
+            return 17 * badge.hashCode() + 93 * version.hashCode();
         }
-        
-        private static final IrcBadges EMPTY = new IrcBadges(new String[0]);
-        
-        public static IrcBadges parse(String data) {
-            if (data == null || data.isEmpty()) {
-                return EMPTY;
-            }
-            String[] badges = data.split(",");
-            String[] result = new String[badges.length * 2];
-            int counter = 0;
-            for (String badge : badges) {
-                String[] split = badge.split("/", 2);
-                if (split.length == 2) {
-                    String id = MiscUtil.intern(split[0]);
-                    String version = MiscUtil.intern(split[1]);
-                    result[counter++] = id;
-                    result[counter++] = version;
-                }
-            }
-            if (counter < result.length) {
-                String[] newResult = new String[counter];
-                System.arraycopy(result, 0, newResult, 0, newResult.length);
-                return new IrcBadges(newResult);
-            }
-            return new IrcBadges(result);
-        }
-        
     }
+
+    private final Badge[] badges;
+
+    private IrcBadges(Badge[] badges) {
+        this.badges = badges;
+    }
+
+    public String getVersion(String id) {
+        for (Badge badge : badges) {
+            if (badge.badge.equals(id)) {
+                return badge.version;
+            }
+        }
+        return null;
+    }
+
+    public boolean hasId(String id) {
+        return getVersion(id) != null;
+    }
+
+    public boolean hasIdVersion(String id, String version) {
+        String actualVersion = getVersion(id);
+        return actualVersion != null && actualVersion.equals(version);
+    }
+
+    public String getVersion(int i) {
+        return badges[i].version;
+    }
+
+    public String getId(int i) {
+        return badges[i].badge;
+    }
+
+    public int size() {
+        return badges.length;
+    }
+
+    public boolean isEmpty() {
+        return badges.length == 0;
+    }
+
+    public void forEach(BiConsumer<String, String> consumer) {
+        for (Badge badge : badges) {
+            consumer.accept(badge.badge, badge.version);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return Arrays.stream(badges).map(Badge::toString).collect(Collectors.joining(","));
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final IrcBadges other = (IrcBadges) obj;
+        return Arrays.deepEquals(this.badges, other.badges);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.deepHashCode(this.badges);
+    }
+
+    private static final IrcBadges EMPTY = new IrcBadges(new Badge[0]);
+
+    public static IrcBadges parse(String data) {
+        if (data == null || data.isEmpty()) {
+            return EMPTY;
+        }
+        String[] badges = data.split(",");
+        List<Badge> result = new ArrayList<Badge>();
+        for (String badge : badges) {
+            String[] split = badge.split("/", 2);
+            if (split.length == 2) {
+                String id = MiscUtil.intern(split[0]);
+                String version = MiscUtil.intern(split[1]);
+                result.add(new Badge(id, version));
+            }
+        }
+        return new IrcBadges(result.toArray(new Badge[0]));
+    }
+}

--- a/src/chatty/util/irc/UserTagsUtil.java
+++ b/src/chatty/util/irc/UserTagsUtil.java
@@ -28,9 +28,9 @@ public class UserTagsUtil {
         }
 
         IrcBadges badgeInfo = IrcBadges.parse(tags.get("badge-info"));
-        String subMonths = badgeInfo.get("subscriber");
+        String subMonths = badgeInfo.getVersion("subscriber");
         if (subMonths == null) {
-            subMonths = badgeInfo.get("founder");
+            subMonths = badgeInfo.getVersion("founder");
         }
         if (subMonths != null) {
             user.setSubMonths(Helper.parseShort(subMonths, (short) 0));

--- a/test/chatty/util/irc/IrcBadgesTest.java
+++ b/test/chatty/util/irc/IrcBadgesTest.java
@@ -29,7 +29,7 @@ public class IrcBadgesTest {
         assertEquals(0, b.size());
         assertFalse(b.hasId("subscriber"));
         assertFalse(b.hasIdVersion("subscriber", "1"));
-        assertNull(b.get("subscriber"));
+        assertNull(b.getVersion("subscriber"));
     }
     
     @Test
@@ -43,33 +43,31 @@ public class IrcBadgesTest {
         assertTrue(b.hasIdVersion("moderator", "1"));
         assertTrue(b.hasIdVersion("partner", "2"));
         assertFalse(b.hasIdVersion("subscriber", "1"));
-        assertNull(b.get("subscriber"));
-        assertEquals("1", b.get("moderator"));
+        assertNull(b.getVersion("subscriber"));
+        assertEquals("1", b.getVersion("moderator"));
         assertEquals("moderator", b.getId(0));
         assertEquals("1", b.getVersion(0));
         assertEquals("partner", b.getId(1));
         assertEquals("2", b.getVersion(1));
-        List<String> list = new ArrayList<>();
-        b.forEach((id, version) -> {
-            list.add(id);
-            list.add(version);
-        });
-        assertEquals(Arrays.asList(new String[]{"moderator", "1", "partner", "2"}), list);
-        
+        assertEquals(b.toString(), "moderator/1,partner/2");
+
         IrcBadges b2 = IrcBadges.parse("subscriber/24");
         assertFalse(b2.isEmpty());
         assertEquals(1, b2.size());
         assertEquals("subscriber", b2.getId(0));
         assertEquals("24", b2.getVersion(0));
-        
+        assertEquals(b2.toString(), "subscriber/24");
+
         IrcBadges b3 = IrcBadges.parse("predictions/A/B,subscriber/1");
-        assertEquals("1", b3.get("subscriber"));
-        assertEquals("A/B", b3.get("predictions"));
+        assertEquals("1", b3.getVersion("subscriber"));
+        assertEquals("A/B", b3.getVersion("predictions"));
         assertEquals(2, b3.size());
-        
+        assertEquals(b3.toString(), "predictions/A/B,subscriber/1");
+
         IrcBadges b4 = IrcBadges.parse("123/ABC,,,");
-        assertEquals("ABC", b4.get("123"));
+        assertEquals("ABC", b4.getVersion("123"));
         assertEquals(1, b4.size());
+        assertEquals(b4.toString(), "123/ABC");
     }
     
 }


### PR DESCRIPTION
The current version of class `IRCBadges` does not implement `toString()`, so an identifier for custom commands `$(twitch-badge-info)` returns a nonsensical value. Also I got rid of current convoluted implementation by adding a class `Badge`. It adds one additional object per `IRCBadges` instance, which does not add a lot of memory usage.